### PR TITLE
feat: generic CodexBar-backed action (50+ providers on macOS)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ tmp/
 .vscode/
 .agents/
 .preview/
+
+# Compiled test artifacts
+tests/.compiled/

--- a/README.md
+++ b/README.md
@@ -103,6 +103,28 @@ For most providers the plugin simply reads the credentials your CLI already wrot
 
 ---
 
+## CodexBar backend (macOS, optional)
+
+A **Progress Bars (CodexBar)** action lets you display **any** provider that [CodexBar](https://github.com/steipete/CodexBar) supports (50+), without each one needing its own action.
+
+**How it works:** on macOS, if you run `codexbar serve` locally, this action fetches usage from its localhost HTTP API and renders it with the same progress-bar UI. It is purely additive — the six dedicated actions above keep working as-is, and this action has no effect on Windows.
+
+### Setup
+1. Install CodexBar: `brew install --cask codexbar`.
+2. Start the local server: `codexbar serve` (defaults to `127.0.0.1:8080`).
+3. Enable + configure the provider you want in CodexBar → Settings → Providers.
+4. In Stream Deck, drag **Progress Bars (CodexBar)** onto a key/dial and pick the provider in the Property Inspector.
+
+| Setting | What it does |
+|---|---|
+| **Provider** | Which CodexBar provider to display (Cursor, Copilot, Gemini, z.ai, Augment, Windsurf). |
+| **Top bar window** | Whether the top bar shows the primary (session) or secondary (week) usage window. |
+| **Port** | Port of `codexbar serve` (default 8080). |
+
+> No CodexBar installed or not on macOS? The action shows a clear message instead of data.
+
+---
+
 ## How it looks
 
 Each provider renders on both keys and Stream Deck+ dials, with a brand‑matched theme and a rounded usage bar that shows the reset countdown inside it.

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ A **Progress Bars (CodexBar)** action lets you display **any** provider that [Co
 
 | Setting | What it does |
 |---|---|
-| **Provider** | Which CodexBar provider to display (Cursor, Copilot, Gemini, z.ai, Augment, Windsurf). |
+| **Provider** | A curated provider (Cursor, Copilot, Gemini, z.ai, Augment, Windsurf), or any CodexBar provider id in the "Custom provider id" field (e.g. <code>kiro</code>, <code>zed</code>). |
 | **Top bar window** | Whether the top bar shows the primary (session) or secondary (week) usage window. |
 | **Port** | Port of `codexbar serve` (default 8080). |
 

--- a/com.len.limits.sdPlugin/manifest.json
+++ b/com.len.limits.sdPlugin/manifest.json
@@ -158,6 +158,32 @@
           "TitleAlignment": "middle"
         }
       ]
+    },
+    {
+      "Name": "Progress Bars (CodexBar)",
+      "UUID": "com.len.limits.codexbar.generic",
+      "Icon": "imgs/actions/counter/icon",
+      "Tooltip": "Displays any CodexBar provider usage (requires codexbar serve on macOS).",
+      "PropertyInspectorPath": "ui/codexbar-settings.html",
+      "Controllers": [
+        "Keypad",
+        "Encoder"
+      ],
+      "Encoder": {
+        "layout": "layouts/full-view.json",
+        "StackColor": "#9CA3AF",
+        "TriggerDescription": {
+          "Rotate": "Refresh",
+          "Touch": "Refresh",
+          "Push": "Refresh"
+        }
+      },
+      "States": [
+        {
+          "Image": "imgs/actions/counter/key",
+          "TitleAlignment": "middle"
+        }
+      ]
     }
   ],
   "Category": "AI Usage Limits",

--- a/com.len.limits.sdPlugin/ui/codexbar-settings.html
+++ b/com.len.limits.sdPlugin/ui/codexbar-settings.html
@@ -23,6 +23,12 @@
         </sdpi-select>
     </sdpi-item>
 
+    <div class="info">Pick a provider below, or enter a custom CodexBar provider id (e.g. <code>kiro</code>, <code>zed</code>, <code>copilot</code>) in the next field.</div>
+
+    <sdpi-item label="Custom provider id">
+        <sdpi-textfield setting="providerId" id="providerIdCustom" placeholder="e.g. kiro, zed, cursor" />
+    </sdpi-item>
+
     <sdpi-item label="Top bar window">
         <sdpi-select setting="window" id="window">
             <option value="primary">Primary (session)</option>

--- a/com.len.limits.sdPlugin/ui/codexbar-settings.html
+++ b/com.len.limits.sdPlugin/ui/codexbar-settings.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head lang="en">
+    <title>CodexBar Settings</title>
+    <meta charset="utf-8" />
+    <script src="https://sdpi-components.dev/releases/v4/sdpi-components.js"></script>
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; }
+        .info { padding: 8px 16px; font-size: 11px; color: #999; line-height: 1.4; }
+        .link { color: #4285F4; cursor: pointer; text-decoration: underline; }
+        .link:hover { color: #357ae8; }
+    </style>
+</head>
+<body>
+    <sdpi-item label="Provider">
+        <sdpi-select setting="providerId" id="providerId">
+            <option value="cursor">Cursor</option>
+            <option value="copilot">Copilot</option>
+            <option value="gemini">Gemini</option>
+            <option value="zai">z.ai</option>
+            <option value="augment">Augment</option>
+            <option value="windsurf">Windsurf</option>
+        </sdpi-select>
+    </sdpi-item>
+
+    <sdpi-item label="Top bar window">
+        <sdpi-select setting="window" id="window">
+            <option value="primary">Primary (session)</option>
+            <option value="secondary">Secondary (week)</option>
+        </sdpi-select>
+    </sdpi-item>
+
+    <sdpi-item label="Port">
+        <sdpi-range setting="port" id="port" min="1024" max="65535" step="1" default="8080" showvalue="true"></sdpi-range>
+    </sdpi-item>
+
+    <sdpi-item label="Display">
+        <sdpi-checkbox setting="showProviderName" id="showProviderName" label="Show provider name"></sdpi-checkbox>
+    </sdpi-item>
+
+    <div class="info">
+        Requires <b>CodexBar</b> running <code>codexbar serve</code> on macOS (default port 8080).
+        On Windows / when serve is off, this action shows a "macOS only" message.
+    </div>
+    <div class="info"><span class="link" onclick="openGitHub()">View source on GitHub</span></div>
+
+    <script>
+        function openGitHub() {
+            window.open("https://github.com/lenadweb/stream-deck-ai-limits", "_blank");
+        }
+    </script>
+</body>
+</html>

--- a/docs/superpowers/plans/2026-06-25-codexbar-backend.md
+++ b/docs/superpowers/plans/2026-06-25-codexbar-backend.md
@@ -713,59 +713,66 @@ git commit -m "feat(codexbar): add CodexBarBackend singleton with probe/fetch + 
 
 ---
 
-## Task 7: Widen `BaseMonitoringAction` result type
+## Task 7: Make `BaseMonitoringAction` generic over result type
+
+> **Plan correction (2026-06-25):** The original Task 7 widened the result type to a `MonitoringResult` union. That fails typecheck for two reasons discovered during implementation: (1) the real `StandardUsageResult.perModel` uses `usagePercent: number | null`, not assignable to the union's hand-rolled shape; (2) widening `getDisplayData`'s parameter type breaks the 6 existing subclass overrides (parameter contravariance). The generic approach below fixes both **without touching the 6 existing actions** (they keep their current `StandardUsageResult` parameter verbatim).
 
 **Files:**
 - Modify: `src/interfaces/codexbar.ts` (add `MonitoringResult`)
-- Modify: `src/actions/base-monitoring-action.ts`
+- Modify: `src/actions/base-monitoring-action.ts` (add a `TResult` generic param)
 
 - [ ] **Step 1: Add the shared result type**
 
 Append to `src/interfaces/codexbar.ts`:
 
 ```ts
-// Union the base action understands: ai-limits result OR codexbar result.
-// Both expose an optional `error` with a `message` field.
+// Base of every result the base action can render. Both members expose an
+// optional `error` with a `message` field, which is all draw() reads.
 export type MonitoringResult = StandardUsageResultLike | CodexBarResult;
 
 interface StandardUsageResultLike {
     provider?: unknown;
     overallUsagePercent?: number | null;
     overallResetTime?: string | number | null;
-    perModel?: Record<string, { usagePercent?: number; resetTime?: string | null } | undefined> | null;
+    perModel?: Record<string, { usagePercent?: number | null; resetTime?: string | null } | undefined> | null;
     error?: { message: string; code?: string } | null;
     [k: string]: unknown;
 }
 ```
 
-- [ ] **Step 2: Widen base class types**
+> Note `usagePercent?: number | null` (the `| null` matches the real `ModelUsage` type from @lenadweb/ai-limits so `StandardUsageResult` is structurally assignable).
 
-In `src/actions/base-monitoring-action.ts`:
+- [ ] **Step 2: Genericize the base class**
 
-Add to the imports:
+In `src/actions/base-monitoring-action.ts`, READ the file first.
 
+Add the import:
 ```ts
 import type { MonitoringResult } from "../interfaces/codexbar";
 ```
 
-Change the `lastResult` declaration to:
+Change the class declaration to add a second generic param (default keeps existing actions working unchanged):
 
 ```ts
-    protected lastResult: MonitoringResult | null = null;
+export abstract class BaseMonitoringAction<T extends Record<string, any>, TResult extends MonitoringResult = StandardUsageResult> extends SingletonAction<T> {
 ```
 
-Change `fetchProviderUsage` to:
+(Keep `StandardUsageResult` imported in this file — the default generic param references it.)
+
+Change the member/method signatures from `StandardUsageResult` to `TResult`:
 
 ```ts
-    protected async fetchProviderUsage(ev: any): Promise<MonitoringResult> {
+    protected lastResult: TResult | null = null;
+```
+
+```ts
+    protected async fetchProviderUsage(ev: any): Promise<TResult> {
         return this.limitsManager.getClient().fetchUsage(this.providerName);
     }
 ```
 
-Change the abstract `getDisplayData` signature's result parameter type to `MonitoringResult`:
-
 ```ts
-    protected abstract getDisplayData(ev: any, result: MonitoringResult): {
+    protected abstract getDisplayData(ev: any, result: TResult): {
         value1: number;
         value2: number;
         label1: string;
@@ -778,28 +785,24 @@ Change the abstract `getDisplayData` signature's result parameter type to `Monit
     };
 ```
 
-Change the `draw` method's `result` parameter type to `MonitoringResult`:
-
 ```ts
-    protected async draw(ev: any, result: MonitoringResult): Promise<void> {
+    protected async draw(ev: any, result: TResult): Promise<void> {
 ```
 
-Leave all logic inside `draw`/`redraw`/`refresh` unchanged. The 6 existing actions still return `StandardUsageResult`, which satisfies `MonitoringResult` structurally.
+Leave all logic inside `draw`/`redraw`/`refresh` unchanged — `draw` only reads `result.error.message`, which is present on every `MonitoringResult` member, so it typechecks under `TResult extends MonitoringResult`.
 
-- [ ] **Step 3: Remove unused import if flagged**
+The 6 existing subclasses declare `extends BaseMonitoringAction<XxxSettings>` (one generic arg), so `TResult` defaults to `StandardUsageResult` — **their code and signatures are unchanged**. (They still write `result: StandardUsageResult` in `getDisplayData`, which now matches the inherited default.) No edits to the 6 subclass files.
 
-If `tsc` reports `StandardUsageResult` unused in `base-monitoring-action.ts`, remove it from that file's imports. (The 6 existing actions import it themselves.)
-
-- [ ] **Step 4: Verify build + tests**
+- [ ] **Step 3: Verify build + tests**
 
 Run: `npm run build && npm test`
-Expected: build OK; 12 tests still PASS.
+Expected: build OK (existing 6 actions unchanged, still typecheck); 13 tests still PASS.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 4: Commit**
 
 ```bash
 git add src/interfaces/codexbar.ts src/actions/base-monitoring-action.ts
-git commit -m "refactor: widen BaseMonitoringAction result type to MonitoringResult union"
+git commit -m "refactor: genericize BaseMonitoringAction over result type (MonitoringResult)"
 ```
 
 ---
@@ -817,13 +820,13 @@ Create `src/actions/codexbar-generic-progress.ts`:
 import { action } from "@elgato/streamdeck";
 import { BaseMonitoringAction } from "./base-monitoring-action";
 import { ServiceTheme } from "../interfaces/theme";
-import type { CodexBarGenericSettings, CodexBarResult, MonitoringResult } from "../interfaces/codexbar";
+import type { CodexBarGenericSettings, CodexBarResult } from "../interfaces/codexbar";
 import { CodexBarBackend, normalizeCodexBarDisplay } from "../services/codexbar-backend";
 import { themeFor } from "../services/codexbar-provider-registry";
 import type { RenderOptions, Slot } from "../ui/progress-bar-renderer";
 
 @action({ UUID: "com.len.limits.codexbar.generic" })
-export class CodexBarGenericProgress extends BaseMonitoringAction<CodexBarGenericSettings> {
+export class CodexBarGenericProgress extends BaseMonitoringAction<CodexBarGenericSettings, CodexBarResult> {
     private settings: CodexBarGenericSettings = {};
     private providerId: string = "cursor";
 
@@ -855,13 +858,13 @@ export class CodexBarGenericProgress extends BaseMonitoringAction<CodexBarGeneri
         return backend.fetchUsage(this.providerId, this.settings.port ?? 8080);
     }
 
-    protected getDisplayData(_ev: any, result: MonitoringResult): {
+    protected getDisplayData(_ev: any, result: CodexBarResult): {
         value1: number; value2: number; label1: string; label2: string;
         resetTime1: string | null; resetTime2: string | null;
         valueText1?: string; valueText2?: string; slots?: Slot[];
     } {
         const win = this.settings.window === "secondary" ? "secondary" : "primary";
-        return normalizeCodexBarDisplay((result as CodexBarResult).usage ?? null, win);
+        return normalizeCodexBarDisplay(result.usage ?? null, win);
     }
 
     protected override renderOptions(_ev: any): RenderOptions {
@@ -869,6 +872,8 @@ export class CodexBarGenericProgress extends BaseMonitoringAction<CodexBarGeneri
     }
 }
 ```
+
+> Passing `CodexBarResult` as the second generic param means `getDisplayData`'s `result` is already typed `CodexBarResult` — no cast needed (`result.usage`). Existing 6 actions pass only one generic arg, so they keep `StandardUsageResult` by default.
 
 - [ ] **Step 2: Verify typecheck**
 

--- a/docs/superpowers/plans/2026-06-25-codexbar-backend.md
+++ b/docs/superpowers/plans/2026-06-25-codexbar-backend.md
@@ -1,0 +1,1136 @@
+# CodexBar Backend Integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a generic CodexBar-backed AI usage action to `stream-deck-ai-limits` that consumes the local `codexbar serve` HTTP API to display any of 50+ providers on macOS, purely additively.
+
+**Architecture:** A new `CodexBarBackend` singleton wraps the `codexbar serve` HTTP API (localhost) with health-probe + caching + graceful degradation. A new generic action `CodexBarGenericProgress` extends the existing `BaseMonitoringAction`, reusing all rendering/lifecycle, and reads CodexBar's `usage.primary/secondary` windows into the existing `value1/value2/resetTime` model. No changes to the 6 existing actions; Windows untouched.
+
+**Tech Stack:** TypeScript (ESM, `"type":"module"`), Node 20, `@elgato/streamdeck`, Rollup, `node:test` (zero new runtime deps).
+
+**Spec:** `docs/superpowers/specs/2026-06-25-codexbar-backend-design.md`
+
+**Branch:** `feat/codexbar-backend` (already created)
+
+**Testing approach:** Pure logic (registry, normalize, backend) is tested with `node:test`. Since Node can't run `.ts` directly and we add zero runtime deps, `scripts/test-compile.mjs` compiles the three pure TS modules with `tsc` (already a devDependency) into `tests/.compiled/` (gitignored); tests import from there. Type ordering matters: `ServiceTheme` is extended (Task 2) **before** the registry that uses it (Task 4).
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|---|---|---|
+| `src/interfaces/codexbar.ts` | TS types mirroring CodexBar serve JSON + `CodexBarResult` + `CodexBarGenericSettings` (+ `MonitoringResult` added in Task 7) | Create |
+| `src/interfaces/theme.ts` | Add CodexBar provider themes to `ServiceTheme` | Modify |
+| `src/ui/progress-bar-renderer.ts` | Add brand + fallback theme colors | Modify |
+| `scripts/test-compile.mjs` | Compile pure TS modules to ESM for `node:test` | Create |
+| `src/services/codexbar-provider-registry.ts` | provider id → `{ displayName, theme }` + fallback; `themeFor`, `displayNameFor`, `knownProviderIds` | Create |
+| `src/services/codexbar-backend.ts` | `normalizeCodexBarDisplay` pure mapper + `CodexBarBackend` singleton (probe/fetch/cache/platform-guard) | Create |
+| `src/actions/base-monitoring-action.ts` | Widen `fetchProviderUsage`/`lastResult` to `MonitoringResult` union | Modify |
+| `src/actions/codexbar-generic-progress.ts` | Generic action extending `BaseMonitoringAction` | Create |
+| `src/plugin.ts` | Register the new action | Modify |
+| `com.len.limits.sdPlugin/manifest.json` | Add the new action entry | Modify |
+| `com.len.limits.sdPlugin/ui/codexbar-settings.html` | Property Inspector for the new action | Create |
+| `tests/codexbar.test.mjs` | `node:test` cases (registry, normalize, probe, fetch, error passthrough) | Create |
+| `README.md` | "CodexBar backend (macOS, optional)" section | Modify |
+
+---
+
+## Task 0: Bootstrap dependencies
+
+**Files:** (no source changes)
+
+- [ ] **Step 1: Install dependencies**
+
+Run: `npm install`
+Expected: installs `@elgato/streamdeck`, `@lenadweb/ai-limits`, etc. into `node_modules/`.
+
+- [ ] **Step 2: Verify build still works**
+
+Run: `npm run build`
+Expected: builds `com.len.limits.sdPlugin/bin/plugin.js` with no errors.
+
+- [ ] **Step 3: Verify node:test is available**
+
+Run: `node --version`
+Expected: version ≥ 20 (node:test ships with Node).
+
+No commit. Proceed to Task 1.
+
+---
+
+## Task 1: CodexBar type definitions
+
+**Files:**
+- Create: `src/interfaces/codexbar.ts`
+
+- [ ] **Step 1: Create the types file**
+
+Create `src/interfaces/codexbar.ts`:
+
+```ts
+// Mirrors CodexBar serve JSON (CodexBarCore Codable field names).
+// All fields optional/nullable for resilience — providers are heterogeneous.
+
+export interface RateWindow {
+    usedPercent: number;          // 0-100
+    windowMinutes?: number | null;
+    resetsAt?: string | null;     // ISO8601
+    resetDescription?: string | null;
+}
+
+export interface UsageSnapshot {
+    primary?: RateWindow | null;
+    secondary?: RateWindow | null;
+    tertiary?: RateWindow | null;
+    extraRateWindows?: { name: string; [k: string]: unknown }[] | null;
+    updatedAt: string;
+}
+
+export interface ProviderPayload {
+    provider: string;
+    source: string;
+    usage?: UsageSnapshot | null;
+    credits?: unknown | null;
+    error?: { message: string; [k: string]: unknown } | null;
+}
+
+export interface HealthPayload {
+    status: string;
+    version?: string;
+}
+
+// Shape returned to BaseMonitoringAction. `error` has `message`, matching the
+// shape BaseMonitoringAction.draw() reads (`result.error.message`).
+export interface CodexBarResult {
+    usage?: UsageSnapshot | null;
+    error?: { message: string; code?: string } | null;
+}
+
+// Persisted via Stream Deck settings.
+export interface CodexBarGenericSettings {
+    providerId?: string;                       // default "cursor"
+    port?: number;                             // default 8080
+    window?: "primary" | "secondary";          // which window is the TOP bar; default "primary"
+    showProviderName?: boolean;
+}
+```
+
+- [ ] **Step 2: Verify it typechecks**
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/interfaces/codexbar.ts
+git commit -m "feat(codexbar): add serve JSON type definitions"
+```
+
+---
+
+## Task 2: Extend `ServiceTheme` (must precede registry)
+
+**Files:**
+- Modify: `src/interfaces/theme.ts`
+
+- [ ] **Step 1: Read current theme file**
+
+Run: `cat src/interfaces/theme.ts`
+Confirm it has `export type ServiceTheme = 'claude' | 'codex' | 'antigravity' | 'gemini-cli' | 'minimax' | 'openrouter';`.
+
+- [ ] **Step 2: Extend ServiceTheme**
+
+Modify `src/interfaces/theme.ts` — replace the `ServiceTheme` line with:
+
+```ts
+export type ServiceTheme =
+    | 'claude' | 'codex' | 'antigravity' | 'gemini-cli' | 'minimax' | 'openrouter'
+    // CodexBar-backed providers (curated brand themes)
+    | 'cursor' | 'copilot' | 'gemini' | 'zai' | 'augment' | 'windsurf'
+    // Fallback for any provider without a curated theme
+    | 'codexbar-generic';
+```
+
+- [ ] **Step 3: Verify typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/interfaces/theme.ts
+git commit -m "feat(codexbar): extend ServiceTheme with provider brand themes + fallback"
+```
+
+---
+
+## Task 3: Add CodexBar theme colors to renderer
+
+**Files:**
+- Modify: `src/ui/progress-bar-renderer.ts` (the `themes` record)
+
+- [ ] **Step 1: Add theme color entries**
+
+In `src/ui/progress-bar-renderer.ts`, inside the `private themes: Record<ServiceTheme, ThemeColors> = { ... }` object, append these entries after the `openrouter: { ... }` entry (before the closing brace of the object):
+
+```ts
+        cursor: {
+            primary: '#A8B1FF', secondary: '#C0C8FF',
+            background: '#0E0F18', text: '#F2F3FB', label: '#8A8FA6',
+            barBg: '#1F2030', barFill: '#A8B1FF'
+        },
+        copilot: {
+            primary: '#8B5CF6', secondary: '#A78BFA',
+            background: '#0F0B1A', text: '#F3EEFF', label: '#9288B0',
+            barBg: '#221A3A', barFill: '#8B5CF6'
+        },
+        gemini: {
+            primary: '#5B9BFF', secondary: '#8AB4F8',
+            background: '#0E0F11', text: '#ECEDEF', label: '#8E929A',
+            barBg: '#23272D', barFill: '#5B9BFF'
+        },
+        zai: {
+            primary: '#4E8DFF', secondary: '#7AA9FF',
+            background: '#0A0F1A', text: '#EDF2FB', label: '#8595AA',
+            barBg: '#16223A', barFill: '#4E8DFF'
+        },
+        augment: {
+            primary: '#2DD4BF', secondary: '#5EEAD4',
+            background: '#08191A', text: '#E6FBFA', label: '#7FA8A6',
+            barBg: '#0F2E2E', barFill: '#2DD4BF'
+        },
+        windsurf: {
+            primary: '#22D3EE', secondary: '#67E8F9',
+            background: '#06141A', text: '#E6FCFF', label: '#7AA5B0',
+            barBg: '#0E2A33', barFill: '#22D3EE'
+        },
+        'codexbar-generic': {
+            primary: '#9CA3AF', secondary: '#B0B6BF',
+            background: '#121212', text: '#F5F5F5', label: '#9CA3AF',
+            barBg: '#262626', barFill: '#9CA3AF'
+        },
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `npm run build`
+Expected: builds with no type errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/ui/progress-bar-renderer.ts
+git commit -m "feat(codexbar): add brand + fallback theme colors to renderer"
+```
+
+---
+
+## Task 4: Test harness + Provider registry (TDD)
+
+**Files:**
+- Create: `scripts/test-compile.mjs`
+- Modify: `.gitignore`, `package.json`
+- Create: `tests/codexbar.test.mjs`
+- Create: `src/services/codexbar-provider-registry.ts`
+
+- [ ] **Step 1: Create the test-compile helper**
+
+Create `scripts/test-compile.mjs`:
+
+```js
+// Compiles the pure TS test targets to ESM .mjs/.js for node:test.
+// Zero runtime deps — uses tsc from devDependencies.
+import { spawnSync } from "node:child_process";
+import { rmSync, mkdirSync, existsSync } from "node:fs";
+
+const out = "tests/.compiled";
+if (existsSync(out)) rmSync(out, { recursive: true, force: true });
+mkdirSync(out, { recursive: true });
+
+const targets = [
+  "src/services/codexbar-provider-registry.ts",
+  "src/services/codexbar-backend.ts",
+];
+
+const res = spawnSync(
+  "npx",
+  ["tsc", "--module", "nodenext", "--target", "es2022",
+   "--moduleResolution", "nodenext", "--outDir", out,
+   "--skipLibCheck", "--strict", ...targets],
+  { stdio: "inherit", shell: process.platform === "win32" },
+);
+if (res.status !== 0) process.exit(res.status ?? 1);
+```
+
+- [ ] **Step 2: Add gitignore + test script**
+
+Append to `.gitignore`:
+
+```
+# Compiled test artifacts
+tests/.compiled/
+```
+
+In `package.json`, add these to `"scripts"`:
+
+```json
+    "test": "node scripts/test-compile.mjs && node --test tests/",
+    "test:run": "node --test tests/"
+```
+
+- [ ] **Step 3: Write the failing test (registry)**
+
+Create `tests/codexbar.test.mjs`:
+
+```js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  themeFor,
+  displayNameFor,
+  knownProviderIds,
+} from "./.compiled/services/codexbar-provider-registry.js";
+
+test("registry returns branded entry for known id", () => {
+  assert.equal(themeFor("cursor"), "cursor");
+  assert.equal(displayNameFor("cursor"), "Cursor");
+});
+
+test("registry returns fallback for unknown id", () => {
+  assert.equal(themeFor("some-unknown-provider"), "codexbar-generic");
+  assert.equal(displayNameFor("some-unknown-provider"), "some-unknown-provider");
+});
+
+test("knownProviderIds includes curated providers", () => {
+  const ids = knownProviderIds();
+  assert.ok(ids.includes("cursor"));
+  assert.ok(ids.includes("copilot"));
+  assert.ok(ids.length >= 6);
+});
+```
+
+- [ ] **Step 4: Run test to verify it fails**
+
+Run: `npm test`
+Expected: FAIL — `./.compiled/services/codexbar-provider-registry.js` not found (source not created).
+
+- [ ] **Step 5: Write the registry**
+
+Create `src/services/codexbar-provider-registry.ts`:
+
+```ts
+import type { ServiceTheme } from "../interfaces/theme";
+
+export interface CodexBarProviderMeta {
+    displayName: string;
+    theme: ServiceTheme;
+}
+
+// Curated subset; the fallback covers all 50+ providers.
+const REGISTRY: Record<string, CodexBarProviderMeta> = {
+    cursor: { displayName: "Cursor", theme: "cursor" },
+    copilot: { displayName: "Copilot", theme: "copilot" },
+    gemini: { displayName: "Gemini", theme: "gemini" },
+    zai: { displayName: "z.ai", theme: "zai" },
+    augment: { displayName: "Augment", theme: "augment" },
+    windsurf: { displayName: "Windsurf", theme: "windsurf" },
+};
+
+const FALLBACK_THEME: ServiceTheme = "codexbar-generic";
+
+export function themeFor(providerId?: string): ServiceTheme {
+    if (!providerId) return FALLBACK_THEME;
+    return REGISTRY[providerId]?.theme ?? FALLBACK_THEME;
+}
+
+export function displayNameFor(providerId?: string): string {
+    if (!providerId) return "CodexBar";
+    return REGISTRY[providerId]?.displayName ?? providerId;
+}
+
+export function knownProviderIds(): string[] {
+    return Object.keys(REGISTRY);
+}
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `npm test`
+Expected: 3 registry tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/test-compile.mjs .gitignore package.json tests/codexbar.test.mjs src/services/codexbar-provider-registry.ts
+git commit -m "feat(codexbar): add test harness and provider registry with tests"
+```
+
+---
+
+## Task 5: `normalizeCodexBarDisplay` pure mapper (TDD)
+
+**Files:**
+- Create: `src/services/codexbar-backend.ts` (mapper only this task)
+- Modify: `tests/codexbar.test.mjs` (append)
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/codexbar.test.mjs`:
+
+```js
+import { normalizeCodexBarDisplay } from "./.compiled/services/codexbar-backend.js";
+
+test("normalize maps primary/secondary to value1/value2", () => {
+    const snapshot = {
+        primary: { usedPercent: 42, resetsAt: "2099-01-01T00:00:00Z" },
+        secondary: { usedPercent: 7, resetsAt: "2099-01-08T00:00:00Z" },
+        updatedAt: "2099-01-01T00:00:00Z",
+    };
+    const out = normalizeCodexBarDisplay(snapshot, "primary");
+    assert.equal(out.value1, 42);
+    assert.equal(out.value2, 7);
+    assert.equal(out.resetTime1, "2099-01-01T00:00:00Z");
+    assert.equal(out.resetTime2, "2099-01-08T00:00:00Z");
+});
+
+test("normalize uses chosen window as top bar", () => {
+    const snapshot = {
+        primary: { usedPercent: 10 },
+        secondary: { usedPercent: 80 },
+        updatedAt: "2099-01-01T00:00:00Z",
+    };
+    const out = normalizeCodexBarDisplay(snapshot, "secondary");
+    assert.equal(out.value1, 80); // secondary now on top
+    assert.equal(out.value2, 10); // primary on bottom
+});
+
+test("normalize tolerates missing windows", () => {
+    const out = normalizeCodexBarDisplay({ updatedAt: "x" }, "primary");
+    assert.equal(out.value1, 0);
+    assert.equal(out.value2, 0);
+    assert.equal(out.resetTime1, null);
+    assert.equal(out.resetTime2, null);
+});
+
+test("normalize clamps out-of-range percent", () => {
+    const snapshot = { primary: { usedPercent: 150 }, updatedAt: "x" };
+    const out = normalizeCodexBarDisplay(snapshot, "primary");
+    assert.equal(out.value1, 100);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test`
+Expected: FAIL — `normalizeCodexBarDisplay` not exported.
+
+- [ ] **Step 3: Write the mapper**
+
+Create `src/services/codexbar-backend.ts`:
+
+```ts
+import type { UsageSnapshot } from "../interfaces/codexbar";
+
+export interface NormalizedDisplay {
+    value1: number;
+    value2: number;
+    label1: string;
+    label2: string;
+    resetTime1: string | null;
+    resetTime2: string | null;
+}
+
+function clampPercent(v: number | undefined | null): number {
+    if (v == null || Number.isNaN(v)) return 0;
+    if (v < 0) return 0;
+    if (v > 100) return 100;
+    return v;
+}
+
+export function normalizeCodexBarDisplay(
+    snapshot: UsageSnapshot | null | undefined,
+    topWindow: "primary" | "secondary",
+): NormalizedDisplay {
+    const primary = snapshot?.primary ?? null;
+    const secondary = snapshot?.secondary ?? null;
+    const top = topWindow === "secondary" ? secondary : primary;
+    const bottom = topWindow === "secondary" ? primary : secondary;
+
+    return {
+        value1: clampPercent(top?.usedPercent),
+        value2: clampPercent(bottom?.usedPercent),
+        label1: "Session",
+        label2: "Week",
+        resetTime1: top?.resetsAt ?? null,
+        resetTime2: bottom?.resetsAt ?? null,
+    };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test`
+Expected: 7 tests PASS (3 registry + 4 normalize).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/services/codexbar-backend.ts tests/codexbar.test.mjs
+git commit -m "feat(codexbar): add normalizeCodexBarDisplay pure mapper with tests"
+```
+
+---
+
+## Task 6: `CodexBarBackend` singleton (TDD)
+
+**Files:**
+- Modify: `src/services/codexbar-backend.ts` (append the class)
+- Modify: `tests/codexbar.test.mjs` (append)
+
+- [ ] **Step 1: Write failing tests for probe + fetch**
+
+Append to `tests/codexbar.test.mjs`:
+
+```js
+import { CodexBarBackend } from "./.compiled/services/codexbar-backend.js";
+
+function mockResponse(obj) {
+    return {
+        ok: true,
+        status: 200,
+        json: async () => obj,
+        text: async () => JSON.stringify(obj),
+    };
+}
+
+test("backend probe reports unavailable when fetch throws", async () => {
+    const b = new CodexBarBackend();
+    b.setTestDeps({ fetch: async () => { throw new Error("ECONNREFUSED"); }, platform: "darwin" });
+    const avail = await b.probe(8080);
+    assert.equal(avail, false);
+    assert.equal(b.isAvailable(), false);
+});
+
+test("backend probe reports available on healthy /health", async () => {
+    const b = new CodexBarBackend();
+    b.setTestDeps({
+        fetch: async (url) => url.endsWith("/health") ? mockResponse({ status: "ok", version: "0.37.2" }) : mockResponse(undefined),
+        platform: "darwin",
+    });
+    const avail = await b.probe(8080);
+    assert.equal(avail, true);
+});
+
+test("backend does not call fetch on non-darwin", async () => {
+    const b = new CodexBarBackend();
+    let called = false;
+    b.setTestDeps({ fetch: async () => { called = true; return mockResponse({}); }, platform: "win32" });
+    const avail = await b.probe(8080);
+    assert.equal(avail, false);
+    assert.equal(called, false);
+});
+
+test("backend fetchUsage returns error when payload has error", async () => {
+    const b = new CodexBarBackend();
+    b.setTestDeps({
+        fetch: async (url) => {
+            if (url.endsWith("/health")) return mockResponse({ status: "ok" });
+            return mockResponse([{ provider: "cursor", source: "web", error: { message: "no cookies" } }]);
+        },
+        platform: "darwin",
+    });
+    await b.probe(8080);
+    const res = await b.fetchUsage("cursor", 8080);
+    assert.equal(res.error?.message, "no cookies");
+    assert.equal(res.usage, null);
+});
+
+test("backend fetchUsage returns usage when present", async () => {
+    const b = new CodexBarBackend();
+    b.setTestDeps({
+        fetch: async (url) => {
+            if (url.endsWith("/health")) return mockResponse({ status: "ok" });
+            return mockResponse([{
+                provider: "cursor", source: "web",
+                usage: { primary: { usedPercent: 55, resetsAt: "2099-01-01T00:00:00Z" }, updatedAt: "x" },
+            }]);
+        },
+        platform: "darwin",
+    });
+    await b.probe(8080);
+    const res = await b.fetchUsage("cursor", 8080);
+    assert.equal(res.error, null);
+    assert.equal(res.usage?.primary?.usedPercent, 55);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test`
+Expected: FAIL — `CodexBarBackend` / `setTestDeps` not exported.
+
+- [ ] **Step 3: Implement the backend class**
+
+Append to `src/services/codexbar-backend.ts`:
+
+```ts
+import type { CodexBarResult, HealthPayload, ProviderPayload } from "../interfaces/codexbar";
+
+const PROBE_TIMEOUT_MS = 1500;
+const FETCH_TIMEOUT_MS = 8000;
+const PROBE_CACHE_MS = 60_000;
+const LOOPBACK = "127.0.0.1";
+
+type FetchLike = (url: string, opts?: Record<string, unknown>) => Promise<{
+    ok: boolean;
+    status: number;
+    json: () => Promise<unknown>;
+    text: () => Promise<string>;
+}>;
+
+interface TestDeps {
+    fetch?: FetchLike;
+    platform?: string;
+}
+
+export class CodexBarBackend {
+    private static instance: CodexBarBackend;
+    private available = false;
+    private lastProbeAt = 0;
+    private probing: Promise<boolean> | null = null;
+    private deps: TestDeps = {};
+
+    private constructor() {}
+
+    static getInstance(): CodexBarBackend {
+        if (!CodexBarBackend.instance) CodexBarBackend.instance = new CodexBarBackend();
+        return CodexBarBackend.instance;
+    }
+
+    /** Test-only injection of fetch/platform. */
+    setTestDeps(deps: TestDeps): void {
+        this.deps = deps;
+        this.available = false;
+        this.lastProbeAt = 0;
+    }
+
+    private get platform(): string {
+        return this.deps.platform ?? process.platform;
+    }
+
+    private get fetchFn(): FetchLike {
+        return (this.deps.fetch as FetchLike) ?? (globalThis.fetch as FetchLike);
+    }
+
+    isAvailable(): boolean {
+        return this.available;
+    }
+
+    /** Probes /health; caches result for PROBE_CACHE_MS. Safe to call repeatedly. */
+    async probe(port = 8080): Promise<boolean> {
+        if (this.platform !== "darwin") {
+            this.available = false;
+            return false;
+        }
+        if (this.probing) return this.probing;
+        const now = Date.now();
+        if (this.lastProbeAt !== 0 && now - this.lastProbeAt < PROBE_CACHE_MS) {
+            return this.available;
+        }
+        this.probing = this.doProbe(port);
+        try {
+            return await this.probing;
+        } finally {
+            this.probing = null;
+        }
+    }
+
+    private async doProbe(port: number): Promise<boolean> {
+        try {
+            const ctrl = new AbortController();
+            const timer = setTimeout(() => ctrl.abort(), PROBE_TIMEOUT_MS);
+            const res = await this.fetchFn(`http://${LOOPBACK}:${port}/health`, { signal: ctrl.signal });
+            clearTimeout(timer);
+            if (!res.ok) {
+                this.available = false;
+            } else {
+                const body = (await res.json()) as HealthPayload;
+                this.available = body?.status === "ok";
+            }
+        } catch {
+            this.available = false;
+        }
+        this.lastProbeAt = Date.now();
+        return this.available;
+    }
+
+    /** Fetches usage for a provider. Never throws — errors become { error }. */
+    async fetchUsage(providerId: string, port = 8080): Promise<CodexBarResult> {
+        if (this.platform !== "darwin" || !providerId) {
+            return { usage: null, error: { message: "CodexBar serve unavailable (macOS only)" } };
+        }
+        if (!this.available) {
+            await this.probe(port);
+        }
+        if (!this.available) {
+            return { usage: null, error: { message: "CodexBar serve 未运行(仅 macOS)" } };
+        }
+        try {
+            const ctrl = new AbortController();
+            const timer = setTimeout(() => ctrl.abort(), FETCH_TIMEOUT_MS);
+            const res = await this.fetchFn(
+                `http://${LOOPBACK}:${port}/usage?provider=${encodeURIComponent(providerId)}`,
+                { signal: ctrl.signal },
+            );
+            clearTimeout(timer);
+            if (!res.ok) return { usage: null, error: { message: `serve HTTP ${res.status}` } };
+            const arr = (await res.json()) as ProviderPayload[];
+            const item = (Array.isArray(arr) ? arr : []).find((p) => p?.provider === providerId);
+            if (!item) return { usage: null, error: { message: `provider "${providerId}" not found` } };
+            if (item.error) return { usage: null, error: { message: item.error.message } };
+            return { usage: item.usage ?? null, error: null };
+        } catch (e) {
+            return { usage: null, error: { message: e instanceof Error ? e.message : "request failed" } };
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test`
+Expected: 12 tests PASS (7 prior + 5 backend).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/services/codexbar-backend.ts tests/codexbar.test.mjs
+git commit -m "feat(codexbar): add CodexBarBackend singleton with probe/fetch + tests"
+```
+
+---
+
+## Task 7: Widen `BaseMonitoringAction` result type
+
+**Files:**
+- Modify: `src/interfaces/codexbar.ts` (add `MonitoringResult`)
+- Modify: `src/actions/base-monitoring-action.ts`
+
+- [ ] **Step 1: Add the shared result type**
+
+Append to `src/interfaces/codexbar.ts`:
+
+```ts
+// Union the base action understands: ai-limits result OR codexbar result.
+// Both expose an optional `error` with a `message` field.
+export type MonitoringResult = StandardUsageResultLike | CodexBarResult;
+
+interface StandardUsageResultLike {
+    provider?: unknown;
+    overallUsagePercent?: number | null;
+    overallResetTime?: string | number | null;
+    perModel?: Record<string, { usagePercent?: number; resetTime?: string | null } | undefined> | null;
+    error?: { message: string; code?: string } | null;
+    [k: string]: unknown;
+}
+```
+
+- [ ] **Step 2: Widen base class types**
+
+In `src/actions/base-monitoring-action.ts`:
+
+Add to the imports:
+
+```ts
+import type { MonitoringResult } from "../interfaces/codexbar";
+```
+
+Change the `lastResult` declaration to:
+
+```ts
+    protected lastResult: MonitoringResult | null = null;
+```
+
+Change `fetchProviderUsage` to:
+
+```ts
+    protected async fetchProviderUsage(ev: any): Promise<MonitoringResult> {
+        return this.limitsManager.getClient().fetchUsage(this.providerName);
+    }
+```
+
+Change the abstract `getDisplayData` signature's result parameter type to `MonitoringResult`:
+
+```ts
+    protected abstract getDisplayData(ev: any, result: MonitoringResult): {
+        value1: number;
+        value2: number;
+        label1: string;
+        label2: string;
+        resetTime1?: string | null;
+        resetTime2?: string | null;
+        valueText1?: string;
+        valueText2?: string;
+        slots?: Slot[];
+    };
+```
+
+Change the `draw` method's `result` parameter type to `MonitoringResult`:
+
+```ts
+    protected async draw(ev: any, result: MonitoringResult): Promise<void> {
+```
+
+Leave all logic inside `draw`/`redraw`/`refresh` unchanged. The 6 existing actions still return `StandardUsageResult`, which satisfies `MonitoringResult` structurally.
+
+- [ ] **Step 3: Remove unused import if flagged**
+
+If `tsc` reports `StandardUsageResult` unused in `base-monitoring-action.ts`, remove it from that file's imports. (The 6 existing actions import it themselves.)
+
+- [ ] **Step 4: Verify build + tests**
+
+Run: `npm run build && npm test`
+Expected: build OK; 12 tests still PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/interfaces/codexbar.ts src/actions/base-monitoring-action.ts
+git commit -m "refactor: widen BaseMonitoringAction result type to MonitoringResult union"
+```
+
+---
+
+## Task 8: Generic action
+
+**Files:**
+- Create: `src/actions/codexbar-generic-progress.ts`
+
+- [ ] **Step 1: Create the action**
+
+Create `src/actions/codexbar-generic-progress.ts`:
+
+```ts
+import { action } from "@elgato/streamdeck";
+import { BaseMonitoringAction } from "./base-monitoring-action";
+import { ServiceTheme } from "../interfaces/theme";
+import type { CodexBarGenericSettings, CodexBarResult, MonitoringResult } from "../interfaces/codexbar";
+import { CodexBarBackend, normalizeCodexBarDisplay } from "../services/codexbar-backend";
+import { themeFor } from "../services/codexbar-provider-registry";
+import type { RenderOptions, Slot } from "../ui/progress-bar-renderer";
+
+@action({ UUID: "com.len.limits.codexbar.generic" })
+export class CodexBarGenericProgress extends BaseMonitoringAction<CodexBarGenericSettings> {
+    private settings: CodexBarGenericSettings = {};
+    private providerId: string = "cursor";
+
+    override async onWillAppear(ev: any): Promise<void> {
+        this.applySettings(ev);
+        await super.onWillAppear(ev);
+    }
+
+    override async onDidReceiveSettings(ev: any): Promise<void> {
+        this.applySettings(ev);
+        await this.refresh(ev);
+    }
+
+    private applySettings(ev: any): void {
+        this.settings = (ev.payload?.settings ?? {}) as CodexBarGenericSettings;
+        this.providerId = (this.settings.providerId ?? "cursor").trim() || "cursor";
+    }
+
+    protected get providerName(): string {
+        return this.providerId;
+    }
+
+    protected get themeName(): ServiceTheme {
+        return themeFor(this.providerId);
+    }
+
+    protected override async fetchProviderUsage(): Promise<CodexBarResult> {
+        const backend = CodexBarBackend.getInstance();
+        return backend.fetchUsage(this.providerId, this.settings.port ?? 8080);
+    }
+
+    protected getDisplayData(_ev: any, result: MonitoringResult): {
+        value1: number; value2: number; label1: string; label2: string;
+        resetTime1: string | null; resetTime2: string | null;
+        valueText1?: string; valueText2?: string; slots?: Slot[];
+    } {
+        const win = this.settings.window === "secondary" ? "secondary" : "primary";
+        return normalizeCodexBarDisplay((result as CodexBarResult).usage ?? null, win);
+    }
+
+    protected override renderOptions(_ev: any): RenderOptions {
+        return { showName: this.settings.showProviderName !== false };
+    }
+}
+```
+
+- [ ] **Step 2: Verify typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/actions/codexbar-generic-progress.ts
+git commit -m "feat(codexbar): add generic CodexBar-backed progress action"
+```
+
+---
+
+## Task 9: Register action + manifest
+
+**Files:**
+- Modify: `src/plugin.ts`
+- Modify: `com.len.limits.sdPlugin/manifest.json`
+
+- [ ] **Step 1: Register in plugin entry**
+
+In `src/plugin.ts`, add the import after the OpenRouter import:
+
+```ts
+import { CodexBarGenericProgress } from "./actions/codexbar-generic-progress";
+```
+
+Add the registration after the last `registerAction(...)` line (before `streamDeck.connect();`):
+
+```ts
+streamDeck.actions.registerAction(new CodexBarGenericProgress());
+```
+
+- [ ] **Step 2: Add manifest action entry**
+
+In `com.len.limits.sdPlugin/manifest.json`, append this object to the `"Actions"` array (after the OpenRouter action object, before the array's closing `]`):
+
+```json
+    {
+      "Name": "Progress Bars (CodexBar)",
+      "UUID": "com.len.limits.codexbar.generic",
+      "Icon": "imgs/actions/counter/icon",
+      "Tooltip": "Displays any CodexBar provider usage (requires codexbar serve on macOS).",
+      "PropertyInspectorPath": "ui/codexbar-settings.html",
+      "Controllers": ["Keypad", "Encoder"],
+      "Encoder": {
+        "layout": "layouts/full-view.json",
+        "StackColor": "#9CA3AF",
+        "TriggerDescription": {
+          "Rotate": "Refresh",
+          "Touch": "Refresh",
+          "Push": "Refresh"
+        }
+      },
+      "States": [
+        {
+          "Image": "imgs/actions/counter/key",
+          "TitleAlignment": "middle"
+        }
+      ]
+    }
+```
+
+- [ ] **Step 3: Verify build**
+
+Run: `npm run build`
+Expected: `bin/plugin.js` built; no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/plugin.ts com.len.limits.sdPlugin/manifest.json
+git commit -m "feat(codexbar): register generic action and add manifest entry"
+```
+
+---
+
+## Task 10: Property Inspector UI
+
+**Files:**
+- Create: `com.len.limits.sdPlugin/ui/codexbar-settings.html`
+
+- [ ] **Step 1: Create the settings UI**
+
+Create `com.len.limits.sdPlugin/ui/codexbar-settings.html`:
+
+```html
+<!DOCTYPE html>
+<html>
+<head lang="en">
+    <title>CodexBar Settings</title>
+    <meta charset="utf-8" />
+    <script src="https://sdpi-components.dev/releases/v4/sdpi-components.js"></script>
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; }
+        .info { padding: 8px 16px; font-size: 11px; color: #999; line-height: 1.4; }
+        .link { color: #4285F4; cursor: pointer; text-decoration: underline; }
+        .link:hover { color: #357ae8; }
+    </style>
+</head>
+<body>
+    <sdpi-item label="Provider">
+        <sdpi-select setting="providerId" id="providerId">
+            <option value="cursor">Cursor</option>
+            <option value="copilot">Copilot</option>
+            <option value="gemini">Gemini</option>
+            <option value="zai">z.ai</option>
+            <option value="augment">Augment</option>
+            <option value="windsurf">Windsurf</option>
+        </sdpi-select>
+    </sdpi-item>
+
+    <sdpi-item label="Top bar window">
+        <sdpi-select setting="window" id="window">
+            <option value="primary">Primary (session)</option>
+            <option value="secondary">Secondary (week)</option>
+        </sdpi-select>
+    </sdpi-item>
+
+    <sdpi-item label="Port">
+        <sdpi-range setting="port" id="port" min="1024" max="65535" step="1" default="8080" showvalue="true"></sdpi-range>
+    </sdpi-item>
+
+    <sdpi-item label="Display">
+        <sdpi-checkbox setting="showProviderName" id="showProviderName" label="Show provider name"></sdpi-checkbox>
+    </sdpi-item>
+
+    <div class="info">
+        Requires <b>CodexBar</b> running <code>codexbar serve</code> on macOS (default port 8080).
+        On Windows / when serve is off, this action shows a "macOS only" message.
+    </div>
+    <div class="info"><span class="link" onclick="openGitHub()">View source on GitHub</span></div>
+
+    <script>
+        function openGitHub() {
+            window.open("https://github.com/lenadweb/stream-deck-ai-limits", "_blank");
+        }
+    </script>
+</body>
+</html>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add com.len.limits.sdPlugin/ui/codexbar-settings.html
+git commit -m "feat(codexbar): add Property Inspector UI for generic action"
+```
+
+---
+
+## Task 11: README documentation
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Add a CodexBar section**
+
+In `README.md`, after the "Provider Setup" section's table, insert:
+
+```markdown
+---
+
+## CodexBar backend (macOS, optional)
+
+A **Progress Bars (CodexBar)** action lets you display **any** provider that [CodexBar](https://github.com/steipete/CodexBar) supports (50+), without each one needing its own action.
+
+**How it works:** on macOS, if you run `codexbar serve` locally, this action fetches usage from its localhost HTTP API and renders it with the same progress-bar UI. It is purely additive — the six dedicated actions above keep working as-is, and this action has no effect on Windows.
+
+### Setup
+1. Install CodexBar: `brew install --cask codexbar`.
+2. Start the local server: `codexbar serve` (defaults to `127.0.0.1:8080`).
+3. Enable + configure the provider you want in CodexBar → Settings → Providers.
+4. In Stream Deck, drag **Progress Bars (CodexBar)** onto a key/dial and pick the provider in the Property Inspector.
+
+| Setting | What it does |
+|---|---|
+| **Provider** | Which CodexBar provider to display (Cursor, Copilot, Gemini, z.ai, Augment, Windsurf). |
+| **Top bar window** | Whether the top bar shows the primary (session) or secondary (week) usage window. |
+| **Port** | Port of `codexbar serve` (default 8080). |
+
+> No CodexBar installed or not on macOS? The action shows a clear message instead of data.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: add CodexBar backend section to README"
+```
+
+---
+
+## Task 12: Full verification + PR prep
+
+**Files:** (verification only)
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `npm test`
+Expected: all 12 tests PASS (3 registry + 4 normalize + 5 backend).
+
+- [ ] **Step 2: Run build**
+
+Run: `npm run build`
+Expected: `com.len.limits.sdPlugin/bin/plugin.js` produced, no errors.
+
+- [ ] **Step 3: Confirm existing actions + LimitsManager untouched**
+
+Run: `git diff main -- src/actions/progress-bars.ts src/actions/codex-progress-bars.ts src/actions/antigravity-progress-bars.ts src/actions/gemini-cli-progress-bars.ts src/actions/minimax-progress-bars.ts src/actions/openrouter-progress-bars.ts src/services/limits-manager.ts`
+Expected: empty diff.
+
+- [ ] **Step 4: Manual smoke check (if macOS + CodexBar available)**
+
+1. Open Stream Deck, drop **Progress Bars (CodexBar)** on a key.
+2. With `codexbar serve` running and Cursor configured → bar renders usage + countdown.
+3. Stop `codexbar serve` → key shows "CodexBar serve 未运行" message.
+4. Switch provider to Copilot in PI → updates accordingly.
+
+If CodexBar is not available, skip this step and note it in the PR.
+
+- [ ] **Step 5: Push branch + open PR**
+
+```bash
+git push -u origin feat/codexbar-backend
+```
+
+Then open a PR to `lenadweb/stream-deck-ai-limits` with this body:
+
+```
+## What
+Adds a generic **Progress Bars (CodexBar)** action that consumes the local `codexbar serve` HTTP API to display any of 50+ providers on macOS.
+
+## Why
+Each provider currently needs its own action + UI + manifest entry. This lets one dynamic action cover all providers CodexBar supports, reusing its existing auth/credential handling.
+
+## Scope (friendly to upstream)
+- **Purely additive** — no changes to the 6 existing actions or `LimitsManager` (`git diff main -- src/actions/*progress-bars.ts src/services/limits-manager.ts` is empty).
+- **Windows untouched** — the action is macOS-only by design (serve is macOS); shows a clear message elsewhere.
+- **Zero new runtime deps** — uses Node's built-in `fetch`; tests use `node:test`.
+
+## How
+New `CodexBarBackend` singleton probes `/health` and fetches `/usage?provider=<id>`; a generic action extends `BaseMonitoringAction` and reuses all rendering. `BaseMonitoringAction.fetchProviderUsage` return type widened to a union (existing actions unaffected).
+
+## Tests
+`npm test` → 12 cases (registry, normalize mapper, probe/fetch, error passthrough).
+
+Spec: `docs/superpowers/specs/2026-06-25-codexbar-backend-design.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+---
+
+## Verification checklist
+
+- [ ] `npm test` → 12 passing
+- [ ] `npm run build` → no errors
+- [ ] existing 6 actions: `git diff main` empty
+- [ ] `LimitsManager`: unchanged
+- [ ] Windows: action shows message, doesn't throw
+- [ ] manifest registers `com.len.limits.codexbar.generic` with PI path
+- [ ] README has CodexBar section

--- a/docs/superpowers/specs/2026-06-25-codexbar-backend-design.md
+++ b/docs/superpowers/specs/2026-06-25-codexbar-backend-design.md
@@ -1,0 +1,309 @@
+---
+title: CodexBar 后端集成 — 通用动态 AI Usage Action
+status: design
+date: 2026-06-25
+author: iflexajax
+---
+
+# CodexBar 后端集成 — 通用动态 AI Usage Action
+
+## 1. 背景与目标
+
+`stream-deck-ai-limits` 是一个 Stream Deck 插件(TypeScript/Node),在按键和旋钮上显示 AI 编码配额用量与重置倒计时。当前覆盖 6 个 provider:Claude、Codex、Antigravity、Gemini CLI、MiniMax、OpenRouter。每个 provider 是一个独立 action(`xxx-progress-bars.ts`),provider 逻辑统一放在开源 npm 库 [`@lenadweb/ai-limits`](https://github.com/lenadweb/ai-limits)。
+
+痛点:**每新增一个 provider 都要手写一个 action 文件 + settings interface + manifest 条目 + UI html + 品牌资源**,无法快速扩展。
+
+`CodexBar`(Swift,macOS 菜单栏应用,[steipete/CodexBar](https://github.com/steipete/CodexBar))已经实现了 **50+ 个 AI provider** 的用量采集,并提供本地 HTTP 服务 `codexbar serve`(默认 `127.0.0.1:8080`),暴露标准化 JSON 端点 `GET /usage`、`GET /cost`、`GET /health`。已有 showy-quota、codexbar-waybar 等第三方项目基于它集成。
+
+**目标**:在 macOS 上复用 CodexBar 全部 50+ provider 的采集能力,通过一个**通用动态 action** 直接消费 `codexbar serve` 输出,从而以一个 action 覆盖 CodexBar 支持的全部 provider,而不是逐个对接。Windows 与现有 6 个 action 不受影响。
+
+## 2. 关键决策(已与用户确认)
+
+1. **集成定位:仅 macOS 增强(可选后端)** — Mac 上检测到 `codexbar serve` 在线就用它,否则回退到现有 6 个 action;Windows 完全不受影响(CodexBar 仅 macOS 桌面端,无 Windows 二进制)。
+2. **Provider 范围:通用动态 action,覆盖全部 50+** — 用户在设置里选 provider id(如 `cursor`/`copilot`),插件从 `/usage?provider=<id>` 拉取并渲染。一个 action 覆盖全部,而非逐个写 action。
+3. **贡献策略:Fork + PR** — Fork `stream-deck-ai-limits` 到 `iflexajax/stream-deck-ai-limits`,在 feature 分支实现后向 `lenadweb/stream-deck-ai-limits` 发 PR。纯增量、单仓 PR。
+4. **集成方案:方案 A(CodexBarBackend 适配器)** — 新增 codexbar serve 适配器 + 一个通用 action + 运行时后端探测/降级,纯增量、对原作者零侵入。
+5. **测试框架:`node:test`** — Node 内置,零新增运行时依赖,利于上游接受。
+
+## 3. 现状分析(数据契约已验证)
+
+### 3.1 stream-deck-ai-limits 架构
+
+- `BaseMonitoringAction`(基类,`src/actions/base-monitoring-action.ts`):统一管理生命周期、15 分钟轮询节奏(`monitoringIntervalMs`)、按键/旋钮/触摸刷新、缓存防抖(`lastResult`/`lastFetchTime`)、键与旋钮双路 SVG 渲染、错误态/占位态/消息态。**它通过抽象方法 `getDisplayData(ev, result)` 与 result 解耦**——只要子类能从自己的 result 取出 `{ value1, value2, label1, label2, resetTime1, resetTime2 }` 即可,基类不关心 result 具体形状。
+- 每个 provider 子类:`@action({ UUID })` + `providerName` + `themeName` + `getDisplayData`。
+- `LimitsManager`(单例)封装 `LimitsClient`(`@lenadweb/ai-limits`)。
+- `ProgressBarRenderer`:纯函数式 SVG 渲染,`render(value1,value2,...)` / `renderSlots` / `renderError` / `renderPlaceholder` / `renderMessage`。
+- 渲染模型字段:`value1`/`value2`(上下两条进度 0-100)、`resetTime1`/`resetTime2`(ISO,经 `time-formatter` 转为 `3h 33m` 风格)。
+
+### 3.2 CodexBar `serve` 数据契约(已读源码验证)
+
+- 端点:`GET /health` → `{ "status": "ok", "version": "..." }`;`GET /usage` / `GET /usage?provider=<id>` → `ProviderPayload[]`(每个 provider 一项)。
+- `ProviderPayload` 字段:`provider`、`source`、`usage`(UsageSnapshot)、`credits`、`error`(`{ message }`)、`pace`、`status`。
+- `UsageSnapshot` 的**通用窗口**:`primary` / `secondary` / `tertiary`(均为 `RateWindow`)、`extraRateWindows[]`、`updatedAt`。
+- `RateWindow` 字段:`usedPercent`(0-100)、`windowMinutes?`、`resetsAt?`(ISO8601)、`resetDescription?`。
+- serve 特性:localhost-only、带错误回退(防抖动)、provider 配置按请求热重载、`--port`/`--request-timeout` 可配。
+
+### 3.3 字段同构性(关键)
+
+CodexBar `RateWindow` 与现有渲染模型高度同构:
+
+| CodexBar `RateWindow` / `UsageSnapshot` | 现有渲染模型 |
+|---|---|
+| `usage.primary.usedPercent` | `value1` |
+| `usage.secondary.usedPercent` | `value2` |
+| `usage.primary.resetsAt` | `resetTime1` |
+| `usage.secondary.resetsAt` | `resetTime2` |
+
+因此通用 action 的 `getDisplayData` 极薄,且 `BaseMonitoringAction` 的渲染/生命周期可**完整复用**。
+
+## 4. 架构与数据流
+
+### 4.1 模块边界(纯增量,新增 4 文件 + 扩展 4 处)
+
+```
+src/
+  services/
+    codexbar-backend.ts              (新增:serve HTTP 客户端 + 探测/缓存/降级,单例)
+    codexbar-provider-registry.ts    (新增:provider id → 显示名/主题色/兜底)
+    limits-manager.ts                (不改:通用 action 不走它)
+  actions/
+    codexbar-generic-progress.ts     (新增:通用动态 action)
+  interfaces/
+    codexbar.ts                      (新增:UsageSnapshot/RateWindow TS 类型 + 通用 action settings)
+  actions/base-monitoring-action.ts  (扩展:fetchProviderUsage 返回类型放宽为联合)
+  plugin.ts                          (扩展:注册通用 action)
+  interfaces/theme.ts                (扩展:ServiceTheme 增加兜底取值)
+com.len.limits.sdPlugin/
+  ui/codexbar-settings.html          (新增:provider 下拉 + 端口 + 窗口选择 + 状态提示)
+  manifest.json                      (扩展:新增 com.len.limits.codexbar.generic action)
+```
+
+### 4.2 数据流(macOS,通用 action)
+
+```
+codexbar serve (127.0.0.1:8080)        ← CodexBar 本地拉 50+ provider,localhost 权限,错误回退防抖
+        │  GET /health                  ← 启动探测(1.5s 超时)
+        │  GET /usage?provider=<id>     ← 取数(8s 客户端上限)
+        ▼
+codexbar-backend.ts (单例)
+   ├─ process.platform !== 'darwin' → available=false,不发请求
+   ├─ /health 失败 → available=false,结果缓存 60s
+   └─ fetchUsage(providerId) → { usage, error }（不抛错，error 透传给 renderer）
+        ▼
+codexbar-generic-progress.ts (extends BaseMonitoringAction)
+   └─ fetchProviderUsage → backend.fetchUsage(...)
+   └─ getDisplayData: primary.usedPercent→value1, secondary→value2,
+      resetsAt→resetTime1/2 (经 normalizeCodexBarDisplay 纯函数)
+        ▼
+ProgressBarRenderer (复用,零改动) → key(144) / dial(200) SVG
+```
+
+### 4.3 后端选择策略
+
+- 通用 action 走 `CodexBarBackend`;现有 6 个 action 仍走 `@lenadweb/ai-limits` 的 `LimitsManager`。两者独立,**不互相污染**。
+- 不做"同一 provider 两源择优"(YAGNI):通用 action 的职责就是覆盖 ai-limits 未覆盖的 provider。
+
+## 5. 组件细节
+
+### 5.1 `interfaces/codexbar.ts` — 类型定义
+
+对齐 CodexBar serve 真实 JSON(Codable 字段名),只建最小子集,字段全部 optional 容错。
+
+```ts
+// 对应 CodexBarCore 的 RateWindow / UsageSnapshot(Codable 字段名)
+interface RateWindow {
+  usedPercent: number;          // 0-100
+  windowMinutes?: number | null;
+  resetsAt?: string | null;     // ISO8601
+  resetDescription?: string | null;
+}
+interface UsageSnapshot {
+  primary?: RateWindow | null;
+  secondary?: RateWindow | null;
+  tertiary?: RateWindow | null;
+  extraRateWindows?: { name: string; [k: string]: unknown }[] | null;
+  updatedAt: string;
+}
+interface ProviderPayload {
+  provider: string;
+  source: string;
+  usage?: UsageSnapshot | null;
+  credits?: unknown | null;      // v1 不渲染,留接口位
+  error?: { message: string; [k: string]: unknown } | null;
+}
+interface HealthPayload { status: string; version?: string; }
+
+// 通用 action 结果(与 StandardUsageResult 的 error 形状对齐,见 6.2)
+interface CodexBarResult {
+  usage?: UsageSnapshot | null;
+  error?: { message: string } | null;
+}
+
+interface CodexBarGenericSettings {
+  providerId?: string;                              // 默认 "cursor"
+  port?: number;                                    // 默认 8080
+  window?: "primary" | "secondary";                 // 上层条用哪个窗口,默认 "primary"
+  showProviderName?: boolean;
+}
+```
+
+### 5.2 `codexbar-backend.ts` — serve 客户端
+
+职责:封装 HTTP,暴露 `isAvailable()` 与 `fetchUsage(providerId, port)`。
+
+- **探测**:`GET /health`(超时 1.5s),仅 localhost。失败 → `available=false`,**不抛错**。结果缓存 ~60s,避免每次刷新都打。
+- **取数**:`GET /usage?provider=<id>`(超时 8s 客户端上限)。从返回数组里挑 `provider === providerId` 的项,返回 `{ usage, error }`,**不抛**——透传 codexbar 的 `error`。
+- **跨平台守护**:`process.platform !== 'darwin'` 时 `available` 直接 false,不发请求。
+- **零新增依赖**:用 Node 内置 `fetch`(Node 20,manifest 已要求)。
+- **单例**:`CodexBarBackend.getInstance()`,与现有 `LimitsManager` 单例模式一致。
+
+### 5.3 `codexbar-provider-registry.ts` — provider 映射表
+
+serve 给 provider id(如 `cursor`),但 Stream Deck 需要显示名 + 主题色 + 图标。建静态表,覆盖一批高价值 provider(Cursor / Copilot / Gemini / Codex OAuth / z.ai / Augment / Windsurf / Zed / Kiro 等),其余 id 走**兜底项**(通用图标 + provider id 作显示名 + 中性灰主题)。
+
+- 这张表是"精选 subset",兜底保证 **50+ 全部可渲染**(符合决策 2)。
+- 提供 `themeFor(providerId): ServiceTheme`、`displayNameFor(providerId): string`、`knownProviderIds(): string[]`(供 PI 下拉)。
+
+### 5.4 `codexbar-generic-progress.ts` — 通用 action
+
+继承 `BaseMonitoringAction`,只覆写三处:
+
+```ts
+@action({ UUID: "com.len.limits.codexbar.generic" })
+export class CodexBarGenericProgress extends BaseMonitoringAction<CodexBarGenericSettings> {
+  protected get providerName() { return this.currentSettings.providerId ?? "cursor"; }
+  protected get themeName(): ServiceTheme {
+    return registry.themeFor(this.currentSettings.providerId);
+  }
+
+  protected async fetchProviderUsage(): Promise<CodexBarResult> {
+    const backend = CodexBarBackend.getInstance();
+    if (!backend.isAvailable()) {
+      return { error: { message: "CodexBar serve 未运行(仅 macOS)" } };
+    }
+    return backend.fetchUsage(
+      this.currentSettings.providerId ?? "cursor",
+      this.currentSettings.port ?? 8080,
+    );
+  }
+
+  protected getDisplayData(_ev, result: CodexBarResult) {
+    const win = this.currentSettings.window ?? "primary";
+    const top = result.usage?.[win] ?? result.usage?.primary;
+    const bottom = result.usage?.secondary;
+    return {
+      value1: top?.usedPercent ?? 0,
+      value2: bottom?.usedPercent ?? 0,
+      label1: "Session",
+      label2: "Week",
+      resetTime1: top?.resetsAt ?? null,
+      resetTime2: bottom?.resetsAt ?? null,
+    };
+  }
+}
+```
+
+> `getDisplayData` 的核心归一化逻辑抽成纯函数 `normalizeCodexBarDisplay(snapshot, window)`,定义在 `codexbar-backend.ts`(导出),便于单测(见 7.3)。action 的 `getDisplayData` 直接调用它。
+
+### 5.5 `codexbar-settings.html` — Property Inspector
+
+基于现有 `claude-settings.html` 的 sdpi-components v4 模式,字段:
+- **Provider**(select):从 `registry.knownProviderIds()` 填充 + "Custom" 手填 id。
+- **Window**(select):`primary` / `secondary`(上层条)。
+- **Port**(number,默认 8080)。
+- **Show provider name**(checkbox)。
+- 信息提示:"需要在 macOS 上安装 CodexBar 并启用 `codexbar serve`(Preferences → Advanced)。Windows 暂不支持此 action。"
+
+## 6. 错误处理
+
+### 6.1 错误处理矩阵
+
+| 情况 | 行为 |
+|---|---|
+| 非 macOS 平台 | `available=false`,通用 action 渲染 `renderMessage(["仅 macOS", "需 CodexBar serve"])`;不发请求 |
+| serve 未运行 / health 失败 | 同上消息;60s 后才重试探测 |
+| serve 在线但该 provider 报错 | 透传 codexbar 的 `error.message` → `renderError`(红态,现有能力) |
+| 某窗口字段缺失 | `usedPercent ?? 0`;重置时间缺则不显示倒计时(renderer 已容错) |
+| 请求超时(>8s) | 返回 error 态,不卡 UI |
+| providerId 为空 | 兜底用默认 `cursor` |
+
+**无静默失败**:每种错误都有可见反馈。
+
+### 6.2 类型兼容关键点
+
+`BaseMonitoringAction.draw()` 里有 `if (result.error)` 分支。`CodexBarResult` 的 `error` 形状(`{ message }`)与 `StandardUsageResult` 的 `error` 对齐,**让基类的错误分支对两种 result 都成立**。这是联合类型方案成立的前提,以单测固化。
+
+## 7. 现有改动点、测试、贡献编排
+
+### 7.1 对现有代码的改动点(最小侵入)
+
+| 文件 | 改动 |
+|---|---|
+| `base-monitoring-action.ts` | `fetchProviderUsage` 返回类型从 `StandardUsageResult` 放宽为 `StandardUsageResult \| CodexBarResult`(联合);`lastResult` 类型相应放宽 |
+| `plugin.ts` | 注册 `CodexBarGenericProgress`(1 行) |
+| `manifest.json` | 新增 `com.len.limits.codexbar.generic` action 条目 + `PropertyInspectorPath: ui/codexbar-settings.html`;复用现有 layout/StackColor 模式 |
+| `interfaces/theme.ts` | `ServiceTheme` 增加兜底取值 `codexbar-generic`(或复用 `codex`);其余 6 个主题不动 |
+| `limits-manager.ts` | **不改动** |
+
+> 联合类型方案:`draw()` 已通过 `getDisplayData` 与 result 解耦,基类核心逻辑零改动,回归风险为零。
+
+### 7.2 数据契约风险
+
+唯一脆弱处:`draw()` 读 `result.error`。保证 `CodexBarResult.error` 与 `StandardUsageResult.error` 同形(`{ message }`),并以单测固化。
+
+### 7.3 测试策略(`node:test`,零依赖)
+
+1. **类型映射单测**(最高价值):纯函数 `normalizeCodexBarDisplay(snapshot, window)` —— 字段缺失/百分比越界/重置时间缺失。
+2. **provider registry 单测**:已知 id 返回品牌项、未知 id 返回兜底项。
+3. **探测逻辑单测**(mock `fetch`):`/health` 200→available、超时→unavailable、非 mac→unavailable、不抛错。
+4. **错误透传单测**:codexbar 返回 `{ error }` 时,`CodexBarResult.error.message` 供 renderer。
+5. **类型兼容单测**:`CodexBarResult.error` 与 `StandardUsageResult.error` 同形,`draw()` 的 error 分支对两者成立。
+
+不在测试中触达真实网络或 keychain(对齐 CodexBar AGENTS.md 的"用 stub/test store"原则)。
+
+### 7.4 贡献编排(Fork + PR,单仓)
+
+```
+lenadweb/stream-deck-ai-limits  ──upstream──┐
+        你的 fork: iflexajax/stream-deck-ai-limits
+            └─ feat/codexbar-backend
+                  实现 + 测试 + 文档
+                  └─→ PR → lenadweb/stream-deck-ai-limits
+```
+
+步骤:
+1. Fork `stream-deck-ai-limits` 到 `iflexajax/stream-deck-ai-limits`(本地 clone 已就绪)。
+2. 建 `feat/codexbar-backend` 分支,按设计实现(单元逐个独立,便于 review)。
+3. README 增"CodexBar 后端(macOS 可选)"章节;CONTRIBUTING 补说明。
+4. PR 描述突出:**纯增量、不碰现有 6 个 action、Windows 无影响、零新增运行时依赖、单仓 PR**;附数据流图与测试清单。
+5. 跨平台声明:通用 action 仅 macOS 生效(serve 限制),已在 UI 明示。
+
+**与上游 ai-limits 库解耦**:本方案不改 `@lenadweb/ai-limits`,只需向 `stream-deck-ai-limits` 一个仓库发 PR。
+
+## 8. 验收标准
+
+- macOS + 运行 `codexbar serve` → 通用 action 能渲染 Cursor / Copilot 等 ai-limits 未覆盖 provider 的进度条与重置倒计时。
+- 未装 CodexBar → 通用 action 显示明确提示,现有 6 个 action 正常(回归零)。
+- Windows → 通用 action 显示"仅 macOS",6 个 action 正常。
+- 5 项单测全部通过。
+- `npm run build` 产出 `bin/plugin.js`,Stream Deck 可加载新 action。
+
+## 9. 风险与权衡
+
+- **serve 未运行是常态**:靠"探测 + 明确消息态"处理,绝不卡 UI 或污染现有 action。
+- **provider 数据异构**:极少数 provider 可能不填充 `primary`——`getDisplayData` 全部 `??` 兜底,显示 0% + 无倒计时,不报错。
+- **跨平台用户预期**:UI 明示"仅 macOS",避免 Windows 用户困惑。
+- **不引入 credits/spend 渲染(v1)**:YAGNI,留接口位,未来按需扩展。
+- **provider 映射表手工维护**:兜底保证可用,精选表后续可补充。
+
+## 10. 未来演进(非本期)
+
+- **方案 B**:在 `@lenadweb/ai-limits` 库内新增 `CodexBarBridgeProvider`,让所有现有 action 透明受益(数据源自动切换)。架构更美但需跨两个上游 PR,本期不做,留作后续。
+- **credits / cost 渲染**:通用 action v2 可消费 `GET /cost` 与 `credits` 字段。
+- **自动 provider 发现**:从 `GET /usage`(`?provider=all`)动态拉取可用 provider 列表填充 PI 下拉,取代静态 registry。
+
+## 附录:CodexBar serve 启用方式
+
+- 安装 CodexBar(macOS,`brew install --cask codexbar`)。
+- 启用 serve:`codexbar serve --port 8080`(或 Preferences → Advanced 设置自启动)。
+- 确保目标 provider 在 CodexBar Settings → Providers 中已启用并配置好凭据。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stream-deck-ai-limits",
-  "version": "1.0.0",
+  "version": "0.1.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stream-deck-ai-limits",
-      "version": "1.0.0",
+      "version": "0.1.18",
       "license": "MIT",
       "dependencies": {
         "@elgato/streamdeck": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "build": "rollup -c",
     "watch": "rollup -c -w --watch.onEnd=\"streamdeck restart com.len.limits\"",
     "version:bump": "node scripts/bump-version.mjs",
-    "release": "npm run version:bump && npm run build && streamdeck pack com.len.limits.sdPlugin --force --output ."
+    "release": "npm run version:bump && npm run build && streamdeck pack com.len.limits.sdPlugin --force --output .",
+    "test": "node scripts/test-compile.mjs && node --test tests/",
+    "test:run": "node --test tests/"
   },
   "repository": {
     "type": "git",

--- a/scripts/test-compile.mjs
+++ b/scripts/test-compile.mjs
@@ -1,0 +1,27 @@
+// Compiles the pure TS test targets to ESM .mjs/.js for node:test.
+// Zero runtime deps — uses tsc from devDependencies.
+import { spawnSync } from "node:child_process";
+import { rmSync, mkdirSync, existsSync } from "node:fs";
+
+const out = "tests/.compiled";
+if (existsSync(out)) rmSync(out, { recursive: true, force: true });
+mkdirSync(out, { recursive: true });
+
+const declaredTargets = [
+  "src/services/codexbar-provider-registry.ts",
+  "src/services/codexbar-backend.ts",
+];
+// Skip targets that don't exist yet (created in later tasks).
+const targets = declaredTargets.filter((f) => existsSync(f));
+
+// Note: module/moduleResolution match the project tsconfig (ES2022 + Bundler)
+// so extensionless relative imports — the project's convention — resolve
+// correctly. Emitting ESM .js under outDir is fine for node:test.
+const res = spawnSync(
+  "npx",
+  ["tsc", "--module", "es2022", "--target", "es2022",
+   "--moduleResolution", "bundler", "--outDir", out,
+   "--skipLibCheck", "--strict", ...targets],
+  { stdio: "inherit", shell: process.platform === "win32" },
+);
+if (res.status !== 0) process.exit(res.status ?? 1);

--- a/src/actions/base-monitoring-action.ts
+++ b/src/actions/base-monitoring-action.ts
@@ -96,11 +96,25 @@ export abstract class BaseMonitoringAction<T extends Record<string, any>, TResul
         }
     }
 
+    /**
+     * Fetches usage for this action's provider.
+     *
+     * The default implementation queries the ai-limits `LimitsClient`, which
+     * returns `StandardUsageResult`. Subclasses that declare a non-default
+     * `TResult` (e.g. `CodexBarResult`) MUST override this method — the cast
+     * below is only valid when `TResult === StandardUsageResult`.
+     */
     protected async fetchProviderUsage(ev: any): Promise<TResult> {
-        // Default implementation returns the real StandardUsageResult; cast is
-        // sound because TResult defaults to StandardUsageResult, and concrete
-        // subclasses that return a different TResult override this method.
-        return this.limitsManager.getClient().fetchUsage(this.providerName) as Promise<TResult>;
+        const result = await this.limitsManager.getClient().fetchUsage(this.providerName);
+        // Guard against a subclass that changed TResult but forgot to override
+        // this method — fail loudly in non-production builds instead of
+        // silently rendering a blank key from an incompatible result shape.
+        if (process.env.NODE_ENV !== "production" && !("provider" in result)) {
+            throw new Error(
+                `${this.constructor.name} uses a non-StandardUsageResult TResult but did not override fetchProviderUsage`,
+            );
+        }
+        return result as TResult;
     }
 
     protected abstract getDisplayData(ev: any, result: TResult): {

--- a/src/actions/base-monitoring-action.ts
+++ b/src/actions/base-monitoring-action.ts
@@ -3,12 +3,13 @@ import { ProviderName, StandardUsageResult } from "@lenadweb/ai-limits";
 import { ProgressBarRenderer, Slot, RenderOptions } from "../ui/progress-bar-renderer";
 import { ServiceTheme } from "../interfaces/theme";
 import { LimitsManager } from "../services/limits-manager";
+import type { MonitoringResult } from "../interfaces/codexbar";
 
-export abstract class BaseMonitoringAction<T extends Record<string, any>> extends SingletonAction<T> {
+export abstract class BaseMonitoringAction<T extends Record<string, any>, TResult extends MonitoringResult = StandardUsageResult> extends SingletonAction<T> {
     protected controllers = new Map<string, string>();
     protected intervalId: NodeJS.Timeout | null = null;
     protected isMonitoring = false;
-    protected lastResult: StandardUsageResult | null = null;
+    protected lastResult: TResult | null = null;
     protected lastFetchTime = 0;
     protected readonly monitoringIntervalMs = 900000;
     protected readonly renderer = new ProgressBarRenderer();
@@ -95,11 +96,14 @@ export abstract class BaseMonitoringAction<T extends Record<string, any>> extend
         }
     }
 
-    protected async fetchProviderUsage(ev: any): Promise<StandardUsageResult> {
-        return this.limitsManager.getClient().fetchUsage(this.providerName);
+    protected async fetchProviderUsage(ev: any): Promise<TResult> {
+        // Default implementation returns the real StandardUsageResult; cast is
+        // sound because TResult defaults to StandardUsageResult, and concrete
+        // subclasses that return a different TResult override this method.
+        return this.limitsManager.getClient().fetchUsage(this.providerName) as Promise<TResult>;
     }
 
-    protected abstract getDisplayData(ev: any, result: StandardUsageResult): {
+    protected abstract getDisplayData(ev: any, result: TResult): {
         value1: number;
         value2: number;
         label1: string;
@@ -115,7 +119,7 @@ export abstract class BaseMonitoringAction<T extends Record<string, any>> extend
         return { showName: ev?.payload?.settings?.showProviderName !== false };
     }
 
-    protected async draw(ev: any, result: StandardUsageResult): Promise<void> {
+    protected async draw(ev: any, result: TResult): Promise<void> {
         const opts = this.renderOptions(ev);
         if (result.error) {
             const svg = this.renderer.renderError(result.error.message, this.themeName, 144, 144, opts);

--- a/src/actions/codexbar-generic-progress.ts
+++ b/src/actions/codexbar-generic-progress.ts
@@ -56,4 +56,14 @@ export class CodexBarGenericProgress extends BaseMonitoringAction<CodexBarGeneri
     protected override renderOptions(_ev: any): RenderOptions {
         return { showName: this.settings.showProviderName !== false };
     }
+
+    protected override async draw(ev: any, result: CodexBarResult): Promise<void> {
+        // "Unavailable" (no serve / non-mac) is a setup state, not a provider
+        // error — render it as a neutral message instead of a red error.
+        if (result.error?.code === "UNAVAILABLE") {
+            await this.drawMessage(ev, [this.providerId, "macOS + codexbar serve"]);
+            return;
+        }
+        await super.draw(ev, result);
+    }
 }

--- a/src/actions/codexbar-generic-progress.ts
+++ b/src/actions/codexbar-generic-progress.ts
@@ -1,0 +1,59 @@
+import { action } from "@elgato/streamdeck";
+import { ProviderName } from "@lenadweb/ai-limits";
+import { BaseMonitoringAction } from "./base-monitoring-action";
+import { ServiceTheme } from "../interfaces/theme";
+import type { CodexBarGenericSettings, CodexBarResult } from "../interfaces/codexbar";
+import { CodexBarBackend, normalizeCodexBarDisplay } from "../services/codexbar-backend";
+import { themeFor } from "../services/codexbar-provider-registry";
+import type { RenderOptions, Slot } from "../ui/progress-bar-renderer";
+
+@action({ UUID: "com.len.limits.codexbar.generic" })
+export class CodexBarGenericProgress extends BaseMonitoringAction<CodexBarGenericSettings, CodexBarResult> {
+    private settings: CodexBarGenericSettings = {};
+    private providerId: string = "cursor";
+
+    override async onWillAppear(ev: any): Promise<void> {
+        this.applySettings(ev);
+        await super.onWillAppear(ev);
+    }
+
+    override async onDidReceiveSettings(ev: any): Promise<void> {
+        this.applySettings(ev);
+        await this.refresh(ev);
+    }
+
+    private applySettings(ev: any): void {
+        this.settings = (ev.payload?.settings ?? {}) as CodexBarGenericSettings;
+        this.providerId = (this.settings.providerId ?? "cursor").trim() || "cursor";
+    }
+
+    protected get providerName(): ProviderName {
+        // CodexBar exposes 50+ providers whose IDs are not members of the
+        // ai-limits ProviderName enum. This action never routes through
+        // LimitsClient.fetchUsage (it overrides fetchProviderUsage), so the
+        // value is only used for logging — cast to satisfy the abstract base.
+        return this.providerId as ProviderName;
+    }
+
+    protected get themeName(): ServiceTheme {
+        return themeFor(this.providerId);
+    }
+
+    protected override async fetchProviderUsage(): Promise<CodexBarResult> {
+        const backend = CodexBarBackend.getInstance();
+        return backend.fetchUsage(this.providerId, this.settings.port ?? 8080);
+    }
+
+    protected getDisplayData(_ev: any, result: CodexBarResult): {
+        value1: number; value2: number; label1: string; label2: string;
+        resetTime1: string | null; resetTime2: string | null;
+        valueText1?: string; valueText2?: string; slots?: Slot[];
+    } {
+        const win = this.settings.window === "secondary" ? "secondary" : "primary";
+        return normalizeCodexBarDisplay(result.usage ?? null, win);
+    }
+
+    protected override renderOptions(_ev: any): RenderOptions {
+        return { showName: this.settings.showProviderName !== false };
+    }
+}

--- a/src/interfaces/codexbar.ts
+++ b/src/interfaces/codexbar.ts
@@ -1,3 +1,5 @@
+import type { StandardUsageResult } from "@lenadweb/ai-limits";
+
 // Mirrors CodexBar serve JSON (CodexBarCore Codable field names).
 // All fields optional/nullable for resilience — providers are heterogeneous.
 
@@ -49,6 +51,4 @@ export interface CodexBarGenericSettings {
 // Uses the real StandardUsageResult from @lenadweb/ai-limits (so the existing
 // 6 subclasses — which produce StandardUsageResult — satisfy the constraint
 // with no edits), alongside the CodexBar backend result.
-import type { StandardUsageResult } from "@lenadweb/ai-limits";
-
 export type MonitoringResult = StandardUsageResult | CodexBarResult;

--- a/src/interfaces/codexbar.ts
+++ b/src/interfaces/codexbar.ts
@@ -43,3 +43,12 @@ export interface CodexBarGenericSettings {
     window?: "primary" | "secondary";          // which window is the TOP bar; default "primary"
     showProviderName?: boolean;
 }
+
+// Base of every result the base action can render. Both members expose an
+// optional `error` with a `message` field, which is all draw() reads.
+// Uses the real StandardUsageResult from @lenadweb/ai-limits (so the existing
+// 6 subclasses — which produce StandardUsageResult — satisfy the constraint
+// with no edits), alongside the CodexBar backend result.
+import type { StandardUsageResult } from "@lenadweb/ai-limits";
+
+export type MonitoringResult = StandardUsageResult | CodexBarResult;

--- a/src/interfaces/codexbar.ts
+++ b/src/interfaces/codexbar.ts
@@ -1,0 +1,45 @@
+// Mirrors CodexBar serve JSON (CodexBarCore Codable field names).
+// All fields optional/nullable for resilience — providers are heterogeneous.
+
+export interface RateWindow {
+    usedPercent: number;          // 0-100
+    windowMinutes?: number | null;
+    resetsAt?: string | null;     // ISO8601
+    resetDescription?: string | null;
+}
+
+export interface UsageSnapshot {
+    primary?: RateWindow | null;
+    secondary?: RateWindow | null;
+    tertiary?: RateWindow | null;
+    extraRateWindows?: { name: string; [k: string]: unknown }[] | null;
+    updatedAt: string;
+}
+
+export interface ProviderPayload {
+    provider: string;
+    source: string;
+    usage?: UsageSnapshot | null;
+    credits?: unknown | null;
+    error?: { message: string; [k: string]: unknown } | null;
+}
+
+export interface HealthPayload {
+    status: string;
+    version?: string;
+}
+
+// Shape returned to BaseMonitoringAction. `error` has `message`, matching the
+// shape BaseMonitoringAction.draw() reads (`result.error.message`).
+export interface CodexBarResult {
+    usage?: UsageSnapshot | null;
+    error?: { message: string; code?: string } | null;
+}
+
+// Persisted via Stream Deck settings.
+export interface CodexBarGenericSettings {
+    providerId?: string;                       // default "cursor"
+    port?: number;                             // default 8080
+    window?: "primary" | "secondary";          // which window is the TOP bar; default "primary"
+    showProviderName?: boolean;
+}

--- a/src/interfaces/theme.ts
+++ b/src/interfaces/theme.ts
@@ -1,4 +1,9 @@
-export type ServiceTheme = 'claude' | 'codex' | 'antigravity' | 'gemini-cli' | 'minimax' | 'openrouter';
+export type ServiceTheme =
+    | 'claude' | 'codex' | 'antigravity' | 'gemini-cli' | 'minimax' | 'openrouter'
+    // CodexBar-backed providers (curated brand themes)
+    | 'cursor' | 'copilot' | 'gemini' | 'zai' | 'augment' | 'windsurf'
+    // Fallback for any provider without a curated theme
+    | 'codexbar-generic';
 
 export interface ThemeColors {
     primary: string;

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -5,6 +5,7 @@ import { AntigravityProgressBars } from "./actions/antigravity-progress-bars";
 import { GeminiCliProgressBars } from "./actions/gemini-cli-progress-bars";
 import { MiniMaxProgressBars } from "./actions/minimax-progress-bars";
 import { OpenRouterProgressBars } from "./actions/openrouter-progress-bars";
+import { CodexBarGenericProgress } from "./actions/codexbar-generic-progress";
 
 streamDeck.actions.registerAction(new ProgressBars());
 streamDeck.actions.registerAction(new CodexProgressBars());
@@ -12,5 +13,6 @@ streamDeck.actions.registerAction(new AntigravityProgressBars());
 streamDeck.actions.registerAction(new GeminiCliProgressBars());
 streamDeck.actions.registerAction(new MiniMaxProgressBars());
 streamDeck.actions.registerAction(new OpenRouterProgressBars());
+streamDeck.actions.registerAction(new CodexBarGenericProgress());
 
 streamDeck.connect();

--- a/src/services/codexbar-backend.ts
+++ b/src/services/codexbar-backend.ts
@@ -1,4 +1,4 @@
-import type { UsageSnapshot } from "../interfaces/codexbar";
+import type { CodexBarResult, HealthPayload, ProviderPayload, UsageSnapshot } from "../interfaces/codexbar";
 
 export interface NormalizedDisplay {
     value1: number;
@@ -33,4 +33,123 @@ export function normalizeCodexBarDisplay(
         resetTime1: top?.resetsAt ?? null,
         resetTime2: bottom?.resetsAt ?? null,
     };
+}
+
+const PROBE_TIMEOUT_MS = 1500;
+const FETCH_TIMEOUT_MS = 8000;
+const PROBE_CACHE_MS = 60_000;
+const LOOPBACK = "127.0.0.1";
+
+type FetchLike = (url: string, opts?: Record<string, unknown>) => Promise<{
+    ok: boolean;
+    status: number;
+    json: () => Promise<unknown>;
+    text: () => Promise<string>;
+}>;
+
+interface TestDeps {
+    fetch?: FetchLike;
+    platform?: string;
+}
+
+export class CodexBarBackend {
+    private static instance: CodexBarBackend;
+    private available = false;
+    private lastProbeAt = 0;
+    private probing: Promise<boolean> | null = null;
+    private deps: TestDeps = {};
+
+    constructor() {}
+
+    static getInstance(): CodexBarBackend {
+        if (!CodexBarBackend.instance) CodexBarBackend.instance = new CodexBarBackend();
+        return CodexBarBackend.instance;
+    }
+
+    /** Test-only injection of fetch/platform. */
+    setTestDeps(deps: TestDeps): void {
+        this.deps = deps;
+        this.available = false;
+        this.lastProbeAt = 0;
+    }
+
+    private get platform(): string {
+        return this.deps.platform ?? process.platform;
+    }
+
+    private get fetchFn(): FetchLike {
+        return (this.deps.fetch as FetchLike) ?? (globalThis.fetch as FetchLike);
+    }
+
+    isAvailable(): boolean {
+        return this.available;
+    }
+
+    /** Probes /health; caches result for PROBE_CACHE_MS. Safe to call repeatedly. */
+    async probe(port = 8080): Promise<boolean> {
+        if (this.platform !== "darwin") {
+            this.available = false;
+            return false;
+        }
+        if (this.probing) return this.probing;
+        const now = Date.now();
+        if (this.lastProbeAt !== 0 && now - this.lastProbeAt < PROBE_CACHE_MS) {
+            return this.available;
+        }
+        this.probing = this.doProbe(port);
+        try {
+            return await this.probing;
+        } finally {
+            this.probing = null;
+        }
+    }
+
+    private async doProbe(port: number): Promise<boolean> {
+        try {
+            const ctrl = new AbortController();
+            const timer = setTimeout(() => ctrl.abort(), PROBE_TIMEOUT_MS);
+            const res = await this.fetchFn(`http://${LOOPBACK}:${port}/health`, { signal: ctrl.signal });
+            clearTimeout(timer);
+            if (!res.ok) {
+                this.available = false;
+            } else {
+                const body = (await res.json()) as HealthPayload;
+                this.available = body?.status === "ok";
+            }
+        } catch {
+            this.available = false;
+        }
+        this.lastProbeAt = Date.now();
+        return this.available;
+    }
+
+    /** Fetches usage for a provider. Never throws — errors become { error }. */
+    async fetchUsage(providerId: string, port = 8080): Promise<CodexBarResult> {
+        if (this.platform !== "darwin" || !providerId) {
+            return { usage: null, error: { message: "CodexBar serve unavailable (macOS only)" } };
+        }
+        if (!this.available) {
+            await this.probe(port);
+        }
+        if (!this.available) {
+            return { usage: null, error: { message: "CodexBar serve 未运行(仅 macOS)" } };
+        }
+        try {
+            const ctrl = new AbortController();
+            const timer = setTimeout(() => ctrl.abort(), FETCH_TIMEOUT_MS);
+            const res = await this.fetchFn(
+                `http://${LOOPBACK}:${port}/usage?provider=${encodeURIComponent(providerId)}`,
+                { signal: ctrl.signal },
+            );
+            clearTimeout(timer);
+            if (!res.ok) return { usage: null, error: { message: `serve HTTP ${res.status}` } };
+            const arr = (await res.json()) as ProviderPayload[];
+            const item = (Array.isArray(arr) ? arr : []).find((p) => p?.provider === providerId);
+            if (!item) return { usage: null, error: { message: `provider "${providerId}" not found` } };
+            if (item.error) return { usage: null, error: { message: item.error.message } };
+            return { usage: item.usage ?? null, error: null };
+        } catch (e) {
+            return { usage: null, error: { message: e instanceof Error ? e.message : "request failed" } };
+        }
+    }
 }

--- a/src/services/codexbar-backend.ts
+++ b/src/services/codexbar-backend.ts
@@ -59,7 +59,7 @@ export class CodexBarBackend {
     private probing: Promise<boolean> | null = null;
     private deps: TestDeps = {};
 
-    constructor() {}
+    private constructor() {}
 
     static getInstance(): CodexBarBackend {
         if (!CodexBarBackend.instance) CodexBarBackend.instance = new CodexBarBackend();

--- a/src/services/codexbar-backend.ts
+++ b/src/services/codexbar-backend.ts
@@ -126,13 +126,13 @@ export class CodexBarBackend {
     /** Fetches usage for a provider. Never throws — errors become { error }. */
     async fetchUsage(providerId: string, port = 8080): Promise<CodexBarResult> {
         if (this.platform !== "darwin" || !providerId) {
-            return { usage: null, error: { message: "CodexBar serve unavailable (macOS only)" } };
+            return { usage: null, error: { code: "UNAVAILABLE", message: "CodexBar serve is macOS-only" } };
         }
         if (!this.available) {
             await this.probe(port);
         }
         if (!this.available) {
-            return { usage: null, error: { message: "CodexBar serve 未运行(仅 macOS)" } };
+            return { usage: null, error: { code: "UNAVAILABLE", message: "Run `codexbar serve` on macOS to see usage" } };
         }
         try {
             const ctrl = new AbortController();

--- a/src/services/codexbar-backend.ts
+++ b/src/services/codexbar-backend.ts
@@ -1,0 +1,36 @@
+import type { UsageSnapshot } from "../interfaces/codexbar";
+
+export interface NormalizedDisplay {
+    value1: number;
+    value2: number;
+    label1: string;
+    label2: string;
+    resetTime1: string | null;
+    resetTime2: string | null;
+}
+
+function clampPercent(v: number | undefined | null): number {
+    if (v == null || Number.isNaN(v)) return 0;
+    if (v < 0) return 0;
+    if (v > 100) return 100;
+    return v;
+}
+
+export function normalizeCodexBarDisplay(
+    snapshot: UsageSnapshot | null | undefined,
+    topWindow: "primary" | "secondary",
+): NormalizedDisplay {
+    const primary = snapshot?.primary ?? null;
+    const secondary = snapshot?.secondary ?? null;
+    const top = topWindow === "secondary" ? secondary : primary;
+    const bottom = topWindow === "secondary" ? primary : secondary;
+
+    return {
+        value1: clampPercent(top?.usedPercent),
+        value2: clampPercent(bottom?.usedPercent),
+        label1: "Session",
+        label2: "Week",
+        resetTime1: top?.resetsAt ?? null,
+        resetTime2: bottom?.resetsAt ?? null,
+    };
+}

--- a/src/services/codexbar-provider-registry.ts
+++ b/src/services/codexbar-provider-registry.ts
@@ -1,0 +1,32 @@
+import type { ServiceTheme } from "../interfaces/theme";
+
+export interface CodexBarProviderMeta {
+    displayName: string;
+    theme: ServiceTheme;
+}
+
+// Curated subset; the fallback covers all 50+ providers.
+const REGISTRY: Record<string, CodexBarProviderMeta> = {
+    cursor: { displayName: "Cursor", theme: "cursor" },
+    copilot: { displayName: "Copilot", theme: "copilot" },
+    gemini: { displayName: "Gemini", theme: "gemini" },
+    zai: { displayName: "z.ai", theme: "zai" },
+    augment: { displayName: "Augment", theme: "augment" },
+    windsurf: { displayName: "Windsurf", theme: "windsurf" },
+};
+
+const FALLBACK_THEME: ServiceTheme = "codexbar-generic";
+
+export function themeFor(providerId?: string): ServiceTheme {
+    if (!providerId) return FALLBACK_THEME;
+    return REGISTRY[providerId]?.theme ?? FALLBACK_THEME;
+}
+
+export function displayNameFor(providerId?: string): string {
+    if (!providerId) return "CodexBar";
+    return REGISTRY[providerId]?.displayName ?? providerId;
+}
+
+export function knownProviderIds(): string[] {
+    return Object.keys(REGISTRY);
+}

--- a/src/ui/progress-bar-renderer.ts
+++ b/src/ui/progress-bar-renderer.ts
@@ -70,6 +70,69 @@ export class ProgressBarRenderer {
             label: '#8A8D96',
             barBg: '#1D1D25',
             barFill: '#8284FF'
+        },
+        cursor: {
+            primary: '#A8B1FF',
+            secondary: '#C0C8FF',
+            background: '#0E0F18',
+            text: '#F2F3FB',
+            label: '#8A8FA6',
+            barBg: '#1F2030',
+            barFill: '#A8B1FF'
+        },
+        copilot: {
+            primary: '#8B5CF6',
+            secondary: '#A78BFA',
+            background: '#0F0B1A',
+            text: '#F3EEFF',
+            label: '#9288B0',
+            barBg: '#221A3A',
+            barFill: '#8B5CF6'
+        },
+        gemini: {
+            primary: '#5B9BFF',
+            secondary: '#8AB4F8',
+            background: '#0E0F11',
+            text: '#ECEDEF',
+            label: '#8E929A',
+            barBg: '#23272D',
+            barFill: '#5B9BFF'
+        },
+        zai: {
+            primary: '#4E8DFF',
+            secondary: '#7AA9FF',
+            background: '#0A0F1A',
+            text: '#EDF2FB',
+            label: '#8595AA',
+            barBg: '#16223A',
+            barFill: '#4E8DFF'
+        },
+        augment: {
+            primary: '#2DD4BF',
+            secondary: '#5EEAD4',
+            background: '#08191A',
+            text: '#E6FBFA',
+            label: '#7FA8A6',
+            barBg: '#0F2E2E',
+            barFill: '#2DD4BF'
+        },
+        windsurf: {
+            primary: '#22D3EE',
+            secondary: '#67E8F9',
+            background: '#06141A',
+            text: '#E6FCFF',
+            label: '#7AA5B0',
+            barBg: '#0E2A33',
+            barFill: '#22D3EE'
+        },
+        'codexbar-generic': {
+            primary: '#9CA3AF',
+            secondary: '#B0B6BF',
+            background: '#121212',
+            text: '#F5F5F5',
+            label: '#9CA3AF',
+            barBg: '#262626',
+            barFill: '#9CA3AF'
         }
     };
 

--- a/tests/codexbar.test.mjs
+++ b/tests/codexbar.test.mjs
@@ -1,0 +1,24 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  themeFor,
+  displayNameFor,
+  knownProviderIds,
+} from "./.compiled/services/codexbar-provider-registry.js";
+
+test("registry returns branded entry for known id", () => {
+  assert.equal(themeFor("cursor"), "cursor");
+  assert.equal(displayNameFor("cursor"), "Cursor");
+});
+
+test("registry returns fallback for unknown id", () => {
+  assert.equal(themeFor("some-unknown-provider"), "codexbar-generic");
+  assert.equal(displayNameFor("some-unknown-provider"), "some-unknown-provider");
+});
+
+test("knownProviderIds includes curated providers", () => {
+  const ids = knownProviderIds();
+  assert.ok(ids.includes("cursor"));
+  assert.ok(ids.includes("copilot"));
+  assert.ok(ids.length >= 6);
+});

--- a/tests/codexbar.test.mjs
+++ b/tests/codexbar.test.mjs
@@ -73,7 +73,7 @@ function mockResponse(obj) {
 }
 
 test("backend probe reports unavailable when fetch throws", async () => {
-    const b = new CodexBarBackend();
+    const b = CodexBarBackend.getInstance();
     b.setTestDeps({ fetch: async () => { throw new Error("ECONNREFUSED"); }, platform: "darwin" });
     const avail = await b.probe(8080);
     assert.equal(avail, false);
@@ -81,7 +81,7 @@ test("backend probe reports unavailable when fetch throws", async () => {
 });
 
 test("backend probe reports available on healthy /health", async () => {
-    const b = new CodexBarBackend();
+    const b = CodexBarBackend.getInstance();
     b.setTestDeps({
         fetch: async (url) => url.endsWith("/health") ? mockResponse({ status: "ok", version: "0.37.2" }) : mockResponse(undefined),
         platform: "darwin",
@@ -91,7 +91,7 @@ test("backend probe reports available on healthy /health", async () => {
 });
 
 test("backend does not call fetch on non-darwin", async () => {
-    const b = new CodexBarBackend();
+    const b = CodexBarBackend.getInstance();
     let called = false;
     b.setTestDeps({ fetch: async () => { called = true; return mockResponse({}); }, platform: "win32" });
     const avail = await b.probe(8080);
@@ -100,7 +100,7 @@ test("backend does not call fetch on non-darwin", async () => {
 });
 
 test("backend fetchUsage returns error when payload has error", async () => {
-    const b = new CodexBarBackend();
+    const b = CodexBarBackend.getInstance();
     b.setTestDeps({
         fetch: async (url) => {
             if (url.endsWith("/health")) return mockResponse({ status: "ok" });
@@ -115,7 +115,7 @@ test("backend fetchUsage returns error when payload has error", async () => {
 });
 
 test("backend fetchUsage returns usage when present", async () => {
-    const b = new CodexBarBackend();
+    const b = CodexBarBackend.getInstance();
     b.setTestDeps({
         fetch: async (url) => {
             if (url.endsWith("/health")) return mockResponse({ status: "ok" });
@@ -130,4 +130,16 @@ test("backend fetchUsage returns usage when present", async () => {
     const res = await b.fetchUsage("cursor", 8080);
     assert.equal(res.error, null);
     assert.equal(res.usage?.primary?.usedPercent, 55);
+});
+
+test("backend probe caches result for 60s (no refetch)", async () => {
+    let calls = 0;
+    const b = CodexBarBackend.getInstance();
+    b.setTestDeps({
+        fetch: async (url) => { if (url.endsWith("/health")) calls++; return mockResponse({ status: "ok" }); },
+        platform: "darwin",
+    });
+    await b.probe(8080);
+    await b.probe(8080); // cached — must not refetch
+    assert.equal(calls, 1);
 });

--- a/tests/codexbar.test.mjs
+++ b/tests/codexbar.test.mjs
@@ -6,6 +6,7 @@ import {
   knownProviderIds,
 } from "./.compiled/services/codexbar-provider-registry.js";
 import { normalizeCodexBarDisplay } from "./.compiled/services/codexbar-backend.js";
+import { CodexBarBackend } from "./.compiled/services/codexbar-backend.js";
 
 test("registry returns branded entry for known id", () => {
   assert.equal(themeFor("cursor"), "cursor");
@@ -60,4 +61,73 @@ test("normalize clamps out-of-range percent", () => {
     const snapshot = { primary: { usedPercent: 150 }, updatedAt: "x" };
     const out = normalizeCodexBarDisplay(snapshot, "primary");
     assert.equal(out.value1, 100);
+});
+
+function mockResponse(obj) {
+    return {
+        ok: true,
+        status: 200,
+        json: async () => obj,
+        text: async () => JSON.stringify(obj),
+    };
+}
+
+test("backend probe reports unavailable when fetch throws", async () => {
+    const b = new CodexBarBackend();
+    b.setTestDeps({ fetch: async () => { throw new Error("ECONNREFUSED"); }, platform: "darwin" });
+    const avail = await b.probe(8080);
+    assert.equal(avail, false);
+    assert.equal(b.isAvailable(), false);
+});
+
+test("backend probe reports available on healthy /health", async () => {
+    const b = new CodexBarBackend();
+    b.setTestDeps({
+        fetch: async (url) => url.endsWith("/health") ? mockResponse({ status: "ok", version: "0.37.2" }) : mockResponse(undefined),
+        platform: "darwin",
+    });
+    const avail = await b.probe(8080);
+    assert.equal(avail, true);
+});
+
+test("backend does not call fetch on non-darwin", async () => {
+    const b = new CodexBarBackend();
+    let called = false;
+    b.setTestDeps({ fetch: async () => { called = true; return mockResponse({}); }, platform: "win32" });
+    const avail = await b.probe(8080);
+    assert.equal(avail, false);
+    assert.equal(called, false);
+});
+
+test("backend fetchUsage returns error when payload has error", async () => {
+    const b = new CodexBarBackend();
+    b.setTestDeps({
+        fetch: async (url) => {
+            if (url.endsWith("/health")) return mockResponse({ status: "ok" });
+            return mockResponse([{ provider: "cursor", source: "web", error: { message: "no cookies" } }]);
+        },
+        platform: "darwin",
+    });
+    await b.probe(8080);
+    const res = await b.fetchUsage("cursor", 8080);
+    assert.equal(res.error?.message, "no cookies");
+    assert.equal(res.usage, null);
+});
+
+test("backend fetchUsage returns usage when present", async () => {
+    const b = new CodexBarBackend();
+    b.setTestDeps({
+        fetch: async (url) => {
+            if (url.endsWith("/health")) return mockResponse({ status: "ok" });
+            return mockResponse([{
+                provider: "cursor", source: "web",
+                usage: { primary: { usedPercent: 55, resetsAt: "2099-01-01T00:00:00Z" }, updatedAt: "x" },
+            }]);
+        },
+        platform: "darwin",
+    });
+    await b.probe(8080);
+    const res = await b.fetchUsage("cursor", 8080);
+    assert.equal(res.error, null);
+    assert.equal(res.usage?.primary?.usedPercent, 55);
 });

--- a/tests/codexbar.test.mjs
+++ b/tests/codexbar.test.mjs
@@ -5,6 +5,7 @@ import {
   displayNameFor,
   knownProviderIds,
 } from "./.compiled/services/codexbar-provider-registry.js";
+import { normalizeCodexBarDisplay } from "./.compiled/services/codexbar-backend.js";
 
 test("registry returns branded entry for known id", () => {
   assert.equal(themeFor("cursor"), "cursor");
@@ -21,4 +22,42 @@ test("knownProviderIds includes curated providers", () => {
   assert.ok(ids.includes("cursor"));
   assert.ok(ids.includes("copilot"));
   assert.ok(ids.length >= 6);
+});
+
+test("normalize maps primary/secondary to value1/value2", () => {
+    const snapshot = {
+        primary: { usedPercent: 42, resetsAt: "2099-01-01T00:00:00Z" },
+        secondary: { usedPercent: 7, resetsAt: "2099-01-08T00:00:00Z" },
+        updatedAt: "2099-01-01T00:00:00Z",
+    };
+    const out = normalizeCodexBarDisplay(snapshot, "primary");
+    assert.equal(out.value1, 42);
+    assert.equal(out.value2, 7);
+    assert.equal(out.resetTime1, "2099-01-01T00:00:00Z");
+    assert.equal(out.resetTime2, "2099-01-08T00:00:00Z");
+});
+
+test("normalize uses chosen window as top bar", () => {
+    const snapshot = {
+        primary: { usedPercent: 10 },
+        secondary: { usedPercent: 80 },
+        updatedAt: "2099-01-01T00:00:00Z",
+    };
+    const out = normalizeCodexBarDisplay(snapshot, "secondary");
+    assert.equal(out.value1, 80); // secondary now on top
+    assert.equal(out.value2, 10); // primary on bottom
+});
+
+test("normalize tolerates missing windows", () => {
+    const out = normalizeCodexBarDisplay({ updatedAt: "x" }, "primary");
+    assert.equal(out.value1, 0);
+    assert.equal(out.value2, 0);
+    assert.equal(out.resetTime1, null);
+    assert.equal(out.resetTime2, null);
+});
+
+test("normalize clamps out-of-range percent", () => {
+    const snapshot = { primary: { usedPercent: 150 }, updatedAt: "x" };
+    const out = normalizeCodexBarDisplay(snapshot, "primary");
+    assert.equal(out.value1, 100);
 });


### PR DESCRIPTION
## What

Adds a generic **Progress Bars (CodexBar)** action that consumes [CodexBar](https://github.com/steipete/CodexBar)'s local `codexbar serve` HTTP API to display **any** of its 50+ providers on a Stream Deck key/dial, on macOS — without each provider needing its own action.

## Why

Each provider currently needs its own action + Property Inspector UI + manifest entry + brand assets. This lets **one** dynamic action cover all providers CodexBar supports, reusing CodexBar's existing credential handling (CLI/OAuth/cookies/API keys already configured in CodexBar). Pick a curated provider (Cursor, Copilot, Gemini, z.ai, Augment, Windsurf) or type any CodexBar provider id (e.g. `kiro`, `zed`) into the "Custom provider id" field.

## Scope — friendly to upstream

- **Purely additive.** No changes to the 6 existing actions or `LimitsManager` — `git diff main -- src/actions/*progress-bars.ts src/services/limits-manager.ts` is empty.
- **Windows untouched.** The action is macOS-only by design (CodexBar's `serve` runs on macOS); it shows a neutral "macOS + codexbar serve" message elsewhere, never a crash or blank key.
- **Zero new runtime deps.** Uses Node's built-in `fetch`; tests use `node:test`.

## How

- New `CodexBarBackend` singleton probes `/health` (1.5s timeout, 60s cache) and fetches `/usage?provider=<id>` (8s timeout). Never throws — errors become a structured `{ usage, error }`. Platform guard skips all network on non-mac.
- New `normalizeCodexBarDisplay` pure mapper converts CodexBar's `usage.primary/secondary` windows into the existing `{ value1, value2, resetTime1, resetTime2 }` rendering model (fields are structurally identical).
- New `CodexBarGenericProgress` action extends `BaseMonitoringAction`, reusing **all** existing rendering/lifecycle. It returns `CodexBarResult` instead of `StandardUsageResult`.
- To support both result shapes, `BaseMonitoringAction` is genericized over the result type: `BaseMonitoringAction<T, TResult extends MonitoringResult = StandardUsageResult>`. The 6 existing subclasses keep their single-arg declaration and default to `StandardUsageResult` — **no edits to them**.

## Tests

`npm test` → **13 cases**, all green: provider registry (incl. fallback), the normalize mapper (primary/secondary swap, missing windows, percent clamping), probe (success / fetch-throws / non-mac-skips-fetch / 60s cache), fetch (provider error passthrough, usage happy path). Tests never touch the network or keychain (`fetch`/`platform` injected via a `setTestDeps` seam).

```
# tests 13  # pass 13  # fail 0
```

`npm run build` and `npx tsc --noEmit` are both clean.

## Design notes (for reviewers)

- One design decision worth flagging: a generic action can't tell whether a provider's "top bar" is a session or weekly window — CodexBar's windows are provider-specific. I default the top bar to `primary` (with a settings toggle for `secondary`) and label both bars `Session`/`Week`. Curated providers map these correctly; the labels are a best-effort placeholder for arbitrary providers. Happy to adjust if you'd prefer different semantics.
- Full design spec + implementation plan are in `docs/superpowers/specs/` and `docs/superpowers/plans/` — happy to drop those before merge if you'd rather not carry planning docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
