### PR TITLE
Add ring layout with a per-tile metric picker, and fix Codex weekly window (#6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,12 +77,23 @@ Each provider is a separate action. All of them work on **Keypad** (keys) and **
 
 | Action | What it shows | UUID |
 |---|---|---|
-| **Progress Bars (Claude)** | Claude Code session & weekly usage | `com.len.limits.progress` |
-| **Progress Bars (Codex)** | Codex session usage plus usage limit resets or credits balance | `com.len.limits.codex.progress` |
-| **Progress Bars (Antigravity)** | Antigravity (Claude + Gemini) usage | `com.len.limits.antigravity` |
-| **Progress Bars (Gemini CLI)** | Gemini CLI quota usage | `com.len.limits.gemini-cli` |
-| **Progress Bars (MiniMax)** | MiniMax M-series coding-plan usage | `com.len.limits.minimax` |
+| **Progress Bars (Claude)** | Claude Code session, weekly or Sonnet weekly usage | `com.len.limits.progress` |
+| **Progress Bars (Codex)** | Codex session or weekly usage, usage limit resets, credits balance | `com.len.limits.codex.progress` |
+| **Progress Bars (Antigravity)** | Antigravity (Claude + Gemini) usage, per model | `com.len.limits.antigravity` |
+| **Progress Bars (Gemini CLI)** | Gemini CLI quota usage, per model | `com.len.limits.gemini-cli` |
+| **Progress Bars (MiniMax)** | MiniMax M-series daily or weekly usage | `com.len.limits.minimax` |
 | **Progress Bars (OpenRouter)** | OpenRouter key spend limit & spend by day/week/month | `com.len.limits.openrouter` |
+
+### One metric per tile
+
+Every action has a **Layout** setting:
+
+- **Bars** (default) — the two-slot view, now with a metric picker for each slot.
+- **Ring** — one large ring gauge showing a single metric, with its reset countdown in the middle.
+
+Place the same action more than once to build a row of tiles, e.g. Claude Session, Claude Week, Codex Session and Codex Week side by side. Each tile keeps its own metric, and all tiles of a provider share a single API call, so extra tiles cost nothing.
+
+> **Codex note:** OpenAI currently exposes only a weekly window on Plus, Pro and Business plans ([issue #6](https://github.com/lenadweb/stream-deck-ai-limits/issues/6)). The plugin classifies windows by the duration the API reports, so the weekly usage lands on the **Weekly limit** metric even when the API delivers it in the primary slot. A tile set to **Session limit** shows `no data` until OpenAI brings the 5-hour window back.
 
 ---
 

--- a/com.len.limits.sdPlugin/manifest.json
+++ b/com.len.limits.sdPlugin/manifest.json
@@ -7,7 +7,7 @@
       "Name": "Progress Bars (Claude)",
       "UUID": "com.len.limits.progress",
       "Icon": "imgs/actions/counter/icon",
-      "Tooltip": "Displays Claude usage.",
+      "Tooltip": "Displays Claude usage: session, weekly or Sonnet weekly.",
       "PropertyInspectorPath": "ui/claude-settings.html",
       "Controllers": [
         "Keypad",
@@ -33,7 +33,7 @@
       "Name": "Progress Bars (Codex)",
       "UUID": "com.len.limits.codex.progress",
       "Icon": "imgs/actions/counter/icon",
-      "Tooltip": "Displays Codex usage.",
+      "Tooltip": "Displays Codex usage: session, weekly, usage limit resets or credits.",
       "PropertyInspectorPath": "ui/codex-settings.html",
       "Controllers": [
         "Keypad",

--- a/com.len.limits.sdPlugin/ui/antigravity-settings.html
+++ b/com.len.limits.sdPlugin/ui/antigravity-settings.html
@@ -18,6 +18,9 @@
             border: 1px solid #444;
             font-size: 12px;
         }
+        .hidden {
+            display: none;
+        }
         .info {
             padding: 4px 16px;
             font-size: 11px;
@@ -88,13 +91,26 @@
         <span id="authStatus" class="auth-status">Not signed in</span>
     </div>
 
-    <sdpi-item label="Top Bar Model">
+    <sdpi-item label="Layout">
+        <select id="layout" class="sdpi-item-value">
+            <option value="ring">Ring (one model)</option>
+            <option value="bars">Bars (two models)</option>
+        </select>
+    </sdpi-item>
+
+    <sdpi-item id="ringRow" label="Model">
+        <select id="model" class="sdpi-item-value">
+            <option value="">Overall (Most Constrained)</option>
+        </select>
+    </sdpi-item>
+
+    <sdpi-item id="topRow" label="Top Bar Model">
         <select id="topModel" class="sdpi-item-value">
             <option value="">Overall (Most Constrained)</option>
         </select>
     </sdpi-item>
 
-    <sdpi-item label="Bottom Bar Model">
+    <sdpi-item id="bottomRow" label="Bottom Bar Model">
         <select id="bottomModel" class="sdpi-item-value">
             <option value="">Overall (Most Constrained)</option>
         </select>
@@ -199,46 +215,48 @@
             document.getElementById("loginBtn").disabled = false;
         }
 
+        const MODEL_SELECTS = ["model", "topModel", "bottomModel"];
+
         function populateModels(models, labels) {
-            const topSelect = document.getElementById("topModel");
-            const bottomSelect = document.getElementById("bottomModel");
+            MODEL_SELECTS.forEach(function (id) {
+                const select = document.getElementById(id);
 
-            while (topSelect.options.length > 1) topSelect.remove(1);
-            while (bottomSelect.options.length > 1) bottomSelect.remove(1);
+                while (select.options.length > 1) select.remove(1);
 
-            models.forEach(function (modelId) {
-                const displayName = labels[modelId] || modelId;
-
-                const opt1 = document.createElement("option");
-                opt1.value = modelId;
-                opt1.textContent = displayName;
-                topSelect.appendChild(opt1);
-
-                const opt2 = document.createElement("option");
-                opt2.value = modelId;
-                opt2.textContent = displayName;
-                bottomSelect.appendChild(opt2);
+                models.forEach(function (modelId) {
+                    const opt = document.createElement("option");
+                    opt.value = modelId;
+                    opt.textContent = labels[modelId] || modelId;
+                    select.appendChild(opt);
+                });
             });
 
             applySettings();
         }
 
         function applySettings() {
-            const topSelect = document.getElementById("topModel");
-            const bottomSelect = document.getElementById("bottomModel");
-
-            if (_settings.topModel !== undefined) topSelect.value = _settings.topModel;
-            if (_settings.bottomModel !== undefined) bottomSelect.value = _settings.bottomModel;
+            MODEL_SELECTS.forEach(function (id) {
+                if (_settings[id] !== undefined) document.getElementById(id).value = _settings[id];
+            });
+            document.getElementById("layout").value = _settings.layout || "bars";
             document.getElementById("showProviderName").checked = _settings.showProviderName !== false;
+            applyLayoutVisibility();
+        }
+
+        function applyLayoutVisibility() {
+            const isRing = document.getElementById("layout").value === "ring";
+            document.getElementById("ringRow").classList.toggle("hidden", !isRing);
+            document.getElementById("topRow").classList.toggle("hidden", isRing);
+            document.getElementById("bottomRow").classList.toggle("hidden", isRing);
         }
 
         function saveSettings() {
-            const topSelect = document.getElementById("topModel");
-            const bottomSelect = document.getElementById("bottomModel");
-
-            _settings.topModel = topSelect.value;
-            _settings.bottomModel = bottomSelect.value;
+            MODEL_SELECTS.forEach(function (id) {
+                _settings[id] = document.getElementById(id).value;
+            });
+            _settings.layout = document.getElementById("layout").value || "bars";
             _settings.showProviderName = document.getElementById("showProviderName").checked;
+            applyLayoutVisibility();
 
             if (_websocket && _uuid) {
                 _websocket.send(JSON.stringify({
@@ -261,9 +279,10 @@
         }
 
         document.addEventListener("DOMContentLoaded", function () {
-            document.getElementById("topModel").addEventListener("change", saveSettings);
-            document.getElementById("bottomModel").addEventListener("change", saveSettings);
-            document.getElementById("showProviderName").addEventListener("change", saveSettings);
+            ["layout", "model", "topModel", "bottomModel", "showProviderName"].forEach(function (id) {
+                document.getElementById(id).addEventListener("change", saveSettings);
+            });
+            applySettings();
             document.getElementById("loginBtn").addEventListener("click", function () {
                 const status = document.getElementById("authStatus");
                 status.textContent = "Opening browser…";

--- a/com.len.limits.sdPlugin/ui/claude-settings.html
+++ b/com.len.limits.sdPlugin/ui/claude-settings.html
@@ -36,14 +36,58 @@
             height: 14px;
             cursor: pointer;
         }
+        select.sdpi-item-value {
+            width: 100%;
+            padding: 4px 8px;
+            border-radius: 4px;
+            background: #2d2d2d;
+            color: #ddd;
+            border: 1px solid #444;
+            font-size: 12px;
+        }
+        .hidden {
+            display: none;
+        }
     </style>
 </head>
 
 <body>
+    <sdpi-item label="Layout">
+        <select id="layout" class="sdpi-item-value">
+            <option value="ring">Ring (one metric)</option>
+            <option value="bars">Bars (two metrics)</option>
+        </select>
+    </sdpi-item>
+
+    <sdpi-item id="ringRow" label="Metric">
+        <select id="metric" class="sdpi-item-value">
+            <option value="session">Session (5h)</option>
+            <option value="weekly">Week (7d)</option>
+            <option value="weeklySonnet">Sonnet week (7d)</option>
+        </select>
+    </sdpi-item>
+
+    <sdpi-item id="topRow" label="Top">
+        <select id="topMetric" class="sdpi-item-value">
+            <option value="session">Session (5h)</option>
+            <option value="weekly">Week (7d)</option>
+            <option value="weeklySonnet">Sonnet week (7d)</option>
+        </select>
+    </sdpi-item>
+
+    <sdpi-item id="bottomRow" label="Bottom">
+        <select id="bottomMetric" class="sdpi-item-value">
+            <option value="session">Session (5h)</option>
+            <option value="weekly">Week (7d)</option>
+            <option value="weeklySonnet">Sonnet week (7d)</option>
+        </select>
+    </sdpi-item>
+
     <sdpi-item label="Display">
         <label class="checkbox"><input id="showProviderName" type="checkbox" /> Show provider name</label>
     </sdpi-item>
 
+    <div class="info">Place this action twice to watch two windows side by side, e.g. one tile on Session and one on Week.</div>
     <div class="info">Credentials for Claude are automatically loaded from your system (macOS Keychain or ~/.claude/.credentials.json).</div>
     <div class="info"><span class="link" onclick="openGitHub()">View source on GitHub</span></div>
 
@@ -78,10 +122,27 @@
 
         function applySettings() {
             document.getElementById("showProviderName").checked = _settings.showProviderName !== false;
+            document.getElementById("layout").value = _settings.layout || "bars";
+            document.getElementById("metric").value = _settings.metric || "session";
+            document.getElementById("topMetric").value = _settings.topMetric || "session";
+            document.getElementById("bottomMetric").value = _settings.bottomMetric || "weekly";
+            applyLayoutVisibility();
+        }
+
+        function applyLayoutVisibility() {
+            const isRing = document.getElementById("layout").value === "ring";
+            document.getElementById("ringRow").classList.toggle("hidden", !isRing);
+            document.getElementById("topRow").classList.toggle("hidden", isRing);
+            document.getElementById("bottomRow").classList.toggle("hidden", isRing);
         }
 
         function saveSettings() {
             _settings.showProviderName = document.getElementById("showProviderName").checked;
+            _settings.layout = document.getElementById("layout").value || "bars";
+            _settings.metric = document.getElementById("metric").value || "session";
+            _settings.topMetric = document.getElementById("topMetric").value || "session";
+            _settings.bottomMetric = document.getElementById("bottomMetric").value || "weekly";
+            applyLayoutVisibility();
             if (_websocket && _uuid) {
                 _websocket.send(JSON.stringify({
                     event: "setSettings",
@@ -103,7 +164,9 @@
         }
 
         document.addEventListener("DOMContentLoaded", function () {
-            document.getElementById("showProviderName").addEventListener("change", saveSettings);
+            ["showProviderName", "layout", "metric", "topMetric", "bottomMetric"].forEach(function (id) {
+                document.getElementById(id).addEventListener("change", saveSettings);
+            });
             applySettings();
         });
     </script>

--- a/com.len.limits.sdPlugin/ui/codex-settings.html
+++ b/com.len.limits.sdPlugin/ui/codex-settings.html
@@ -45,23 +45,54 @@
             border: 1px solid #444;
             font-size: 12px;
         }
+        .hidden {
+            display: none;
+        }
     </style>
 </head>
 
 <body>
-    <sdpi-item label="Display">
-        <label class="checkbox"><input id="showProviderName" type="checkbox" /> Show provider name</label>
+    <sdpi-item label="Layout">
+        <select id="layout" class="sdpi-item-value">
+            <option value="ring">Ring (one metric)</option>
+            <option value="bars">Bars (two metrics)</option>
+        </select>
     </sdpi-item>
 
-    <sdpi-item label="Bottom section">
-        <select id="secondaryMetric" class="sdpi-item-value">
+    <sdpi-item id="ringRow" label="Metric">
+        <select id="metric" class="sdpi-item-value">
+            <option value="weekly">Weekly limit</option>
+            <option value="session">Session limit</option>
+            <option value="resetCredits">Usage limit resets</option>
+            <option value="credits">Credits balance</option>
+        </select>
+    </sdpi-item>
+
+    <sdpi-item id="topRow" label="Top">
+        <select id="topMetric" class="sdpi-item-value">
+            <option value="weekly">Weekly limit</option>
+            <option value="session">Session limit</option>
+            <option value="resetCredits">Usage limit resets</option>
+            <option value="credits">Credits balance</option>
+        </select>
+    </sdpi-item>
+
+    <sdpi-item id="bottomRow" label="Bottom">
+        <select id="bottomMetric" class="sdpi-item-value">
+            <option value="weekly">Weekly limit</option>
+            <option value="session">Session limit</option>
             <option value="resetCredits">Usage limit resets</option>
             <option value="credits">Credits balance</option>
             <option value="none">Hide bottom section</option>
         </select>
     </sdpi-item>
 
-    <div class="info">The top section shows your session limit. Choose usage limit resets, credits balance, or hide the bottom section.</div>
+    <sdpi-item label="Display">
+        <label class="checkbox"><input id="showProviderName" type="checkbox" /> Show provider name</label>
+    </sdpi-item>
+
+    <div class="info">Place this action twice to watch two metrics side by side, e.g. one tile on the weekly limit and one on credits.</div>
+    <div class="info">OpenAI currently exposes only a weekly window on Plus, Pro and Business plans. A tile set to the session limit shows "no data" until OpenAI brings the 5-hour window back.</div>
     <div class="info">Credentials for Codex/ChatGPT are automatically loaded from your system (~/.codex/auth.json).</div>
     <div class="info"><span class="link" onclick="openGitHub()">View source on GitHub</span></div>
 
@@ -95,13 +126,32 @@
         }
 
         function applySettings() {
+            // Mirrors the migration in codex-progress-bars.ts: tiles saved before the
+            // metric picker existed only carry secondaryMetric as their bottom slot.
+            const legacy = _settings.secondaryMetric;
             document.getElementById("showProviderName").checked = _settings.showProviderName !== false;
-            document.getElementById("secondaryMetric").value = _settings.secondaryMetric || "resetCredits";
+            document.getElementById("layout").value = _settings.layout || "bars";
+            document.getElementById("metric").value = _settings.metric || "weekly";
+            document.getElementById("topMetric").value = _settings.topMetric || "weekly";
+            document.getElementById("bottomMetric").value = _settings.bottomMetric || legacy || "resetCredits";
+            applyLayoutVisibility();
+        }
+
+        function applyLayoutVisibility() {
+            const isRing = document.getElementById("layout").value === "ring";
+            document.getElementById("ringRow").classList.toggle("hidden", !isRing);
+            document.getElementById("topRow").classList.toggle("hidden", isRing);
+            document.getElementById("bottomRow").classList.toggle("hidden", isRing);
         }
 
         function saveSettings() {
             _settings.showProviderName = document.getElementById("showProviderName").checked;
-            _settings.secondaryMetric = document.getElementById("secondaryMetric").value || "resetCredits";
+            _settings.layout = document.getElementById("layout").value || "bars";
+            _settings.metric = document.getElementById("metric").value || "weekly";
+            _settings.topMetric = document.getElementById("topMetric").value || "weekly";
+            _settings.bottomMetric = document.getElementById("bottomMetric").value || "resetCredits";
+            delete _settings.secondaryMetric;
+            applyLayoutVisibility();
             if (_websocket && _uuid) {
                 _websocket.send(JSON.stringify({
                     event: "setSettings",
@@ -123,8 +173,9 @@
         }
 
         document.addEventListener("DOMContentLoaded", function () {
-            document.getElementById("showProviderName").addEventListener("change", saveSettings);
-            document.getElementById("secondaryMetric").addEventListener("change", saveSettings);
+            ["showProviderName", "layout", "metric", "topMetric", "bottomMetric"].forEach(function (id) {
+                document.getElementById(id).addEventListener("change", saveSettings);
+            });
             applySettings();
         });
     </script>

--- a/com.len.limits.sdPlugin/ui/gemini-settings.html
+++ b/com.len.limits.sdPlugin/ui/gemini-settings.html
@@ -44,17 +44,33 @@
             height: 14px;
             cursor: pointer;
         }
+        .hidden {
+            display: none;
+        }
     </style>
 </head>
 
 <body>
-    <sdpi-item label="Top Bar Model">
+    <sdpi-item label="Layout">
+        <select id="layout" class="sdpi-item-value">
+            <option value="ring">Ring (one model)</option>
+            <option value="bars">Bars (two models)</option>
+        </select>
+    </sdpi-item>
+
+    <sdpi-item id="ringRow" label="Model">
+        <select id="model" class="sdpi-item-value">
+            <option value="">Overall (Most Constrained)</option>
+        </select>
+    </sdpi-item>
+
+    <sdpi-item id="topRow" label="Top Bar Model">
         <select id="topModel" class="sdpi-item-value">
             <option value="">Overall (Most Constrained)</option>
         </select>
     </sdpi-item>
 
-    <sdpi-item label="Bottom Bar Model">
+    <sdpi-item id="bottomRow" label="Bottom Bar Model">
         <select id="bottomModel" class="sdpi-item-value">
             <option value="">Overall (Most Constrained)</option>
         </select>
@@ -125,26 +141,21 @@
             };
         }
 
+        const MODEL_SELECTS = ["model", "topModel", "bottomModel"];
+
         function populateModels(models) {
-            const topSelect = document.getElementById("topModel");
-            const bottomSelect = document.getElementById("bottomModel");
+            MODEL_SELECTS.forEach(function (id) {
+                const select = document.getElementById(id);
 
-            // Clear existing model options (keep first "Overall" option)
-            while (topSelect.options.length > 1) topSelect.remove(1);
-            while (bottomSelect.options.length > 1) bottomSelect.remove(1);
+                // Clear existing model options (keep first "Overall" option)
+                while (select.options.length > 1) select.remove(1);
 
-            models.forEach(function (modelId) {
-                const displayName = modelId.replace(/^models\//, "");
-
-                const opt1 = document.createElement("option");
-                opt1.value = modelId;
-                opt1.textContent = displayName;
-                topSelect.appendChild(opt1);
-
-                const opt2 = document.createElement("option");
-                opt2.value = modelId;
-                opt2.textContent = displayName;
-                bottomSelect.appendChild(opt2);
+                models.forEach(function (modelId) {
+                    const opt = document.createElement("option");
+                    opt.value = modelId;
+                    opt.textContent = modelId.replace(/^models\//, "");
+                    select.appendChild(opt);
+                });
             });
 
             // Restore saved selections
@@ -152,21 +163,28 @@
         }
 
         function applySettings() {
-            const topSelect = document.getElementById("topModel");
-            const bottomSelect = document.getElementById("bottomModel");
-
-            if (_settings.topModel !== undefined) topSelect.value = _settings.topModel;
-            if (_settings.bottomModel !== undefined) bottomSelect.value = _settings.bottomModel;
+            MODEL_SELECTS.forEach(function (id) {
+                if (_settings[id] !== undefined) document.getElementById(id).value = _settings[id];
+            });
+            document.getElementById("layout").value = _settings.layout || "bars";
             document.getElementById("showProviderName").checked = _settings.showProviderName !== false;
+            applyLayoutVisibility();
+        }
+
+        function applyLayoutVisibility() {
+            const isRing = document.getElementById("layout").value === "ring";
+            document.getElementById("ringRow").classList.toggle("hidden", !isRing);
+            document.getElementById("topRow").classList.toggle("hidden", isRing);
+            document.getElementById("bottomRow").classList.toggle("hidden", isRing);
         }
 
         function saveSettings() {
-            const topSelect = document.getElementById("topModel");
-            const bottomSelect = document.getElementById("bottomModel");
-
-            _settings.topModel = topSelect.value;
-            _settings.bottomModel = bottomSelect.value;
+            MODEL_SELECTS.forEach(function (id) {
+                _settings[id] = document.getElementById(id).value;
+            });
+            _settings.layout = document.getElementById("layout").value || "bars";
             _settings.showProviderName = document.getElementById("showProviderName").checked;
+            applyLayoutVisibility();
 
             if (_websocket && _uuid) {
                 const json = {
@@ -190,9 +208,10 @@
         }
 
         document.addEventListener("DOMContentLoaded", function () {
-            document.getElementById("topModel").addEventListener("change", saveSettings);
-            document.getElementById("bottomModel").addEventListener("change", saveSettings);
-            document.getElementById("showProviderName").addEventListener("change", saveSettings);
+            ["layout", "model", "topModel", "bottomModel", "showProviderName"].forEach(function (id) {
+                document.getElementById(id).addEventListener("change", saveSettings);
+            });
+            applySettings();
         });
     </script>
 </body>

--- a/com.len.limits.sdPlugin/ui/minimax-settings.html
+++ b/com.len.limits.sdPlugin/ui/minimax-settings.html
@@ -36,12 +36,52 @@
             height: 14px;
             cursor: pointer;
         }
+        select.sdpi-item-value {
+            width: 100%;
+            padding: 4px 8px;
+            border-radius: 4px;
+            background: #2d2d2d;
+            color: #ddd;
+            border: 1px solid #444;
+            font-size: 12px;
+        }
+        .hidden {
+            display: none;
+        }
     </style>
 </head>
 
 <body>
     <sdpi-item label="API Key">
         <sdpi-textfield id="apiKey" type="password" placeholder="MiniMax API key"></sdpi-textfield>
+    </sdpi-item>
+
+    <sdpi-item label="Layout">
+        <select id="layout" class="sdpi-item-value">
+            <option value="ring">Ring (one metric)</option>
+            <option value="bars">Bars (two metrics)</option>
+        </select>
+    </sdpi-item>
+
+    <sdpi-item id="ringRow" label="Metric">
+        <select id="metric" class="sdpi-item-value">
+            <option value="daily">Daily usage</option>
+            <option value="weekly">Weekly usage</option>
+        </select>
+    </sdpi-item>
+
+    <sdpi-item id="topRow" label="Top">
+        <select id="topMetric" class="sdpi-item-value">
+            <option value="daily">Daily usage</option>
+            <option value="weekly">Weekly usage</option>
+        </select>
+    </sdpi-item>
+
+    <sdpi-item id="bottomRow" label="Bottom">
+        <select id="bottomMetric" class="sdpi-item-value">
+            <option value="daily">Daily usage</option>
+            <option value="weekly">Weekly usage</option>
+        </select>
     </sdpi-item>
 
     <sdpi-item label="Display">
@@ -84,12 +124,29 @@
             const apiKey = document.getElementById("apiKey");
             apiKey.value = _settings.apiKey || "";
             document.getElementById("showProviderName").checked = _settings.showProviderName !== false;
+            document.getElementById("layout").value = _settings.layout || "bars";
+            document.getElementById("metric").value = _settings.metric || "daily";
+            document.getElementById("topMetric").value = _settings.topMetric || "daily";
+            document.getElementById("bottomMetric").value = _settings.bottomMetric || "weekly";
+            applyLayoutVisibility();
+        }
+
+        function applyLayoutVisibility() {
+            const isRing = document.getElementById("layout").value === "ring";
+            document.getElementById("ringRow").classList.toggle("hidden", !isRing);
+            document.getElementById("topRow").classList.toggle("hidden", isRing);
+            document.getElementById("bottomRow").classList.toggle("hidden", isRing);
         }
 
         function saveSettings() {
             const apiKey = document.getElementById("apiKey");
             _settings.apiKey = apiKey.value || "";
             _settings.showProviderName = document.getElementById("showProviderName").checked;
+            _settings.layout = document.getElementById("layout").value || "bars";
+            _settings.metric = document.getElementById("metric").value || "daily";
+            _settings.topMetric = document.getElementById("topMetric").value || "daily";
+            _settings.bottomMetric = document.getElementById("bottomMetric").value || "weekly";
+            applyLayoutVisibility();
 
             if (_websocket && _uuid) {
                 _websocket.send(JSON.stringify({
@@ -114,7 +171,9 @@
         document.addEventListener("DOMContentLoaded", function () {
             const apiKey = document.getElementById("apiKey");
             apiKey.addEventListener("input", saveSettings);
-            document.getElementById("showProviderName").addEventListener("change", saveSettings);
+            ["showProviderName", "layout", "metric", "topMetric", "bottomMetric"].forEach(function (id) {
+                document.getElementById(id).addEventListener("change", saveSettings);
+            });
             applySettings();
         });
     </script>

--- a/com.len.limits.sdPlugin/ui/openrouter-settings.html
+++ b/com.len.limits.sdPlugin/ui/openrouter-settings.html
@@ -18,6 +18,9 @@
             border: 1px solid #444;
             font-size: 12px;
         }
+        .hidden {
+            display: none;
+        }
         .hint {
             padding: 4px 16px;
             font-size: 11px;
@@ -52,7 +55,24 @@
         <sdpi-textfield id="apiKey" type="password" placeholder="OpenRouter API key"></sdpi-textfield>
     </sdpi-item>
 
-    <sdpi-item label="Top Bar">
+    <sdpi-item label="Layout">
+        <select id="layout" class="sdpi-item-value">
+            <option value="ring">Ring (one metric)</option>
+            <option value="bars">Bars (two metrics)</option>
+        </select>
+    </sdpi-item>
+
+    <sdpi-item id="ringRow" label="Metric">
+        <select id="metric" class="sdpi-item-value">
+            <option value="limit">Key Limit (%)</option>
+            <option value="daily">Spend Today ($)</option>
+            <option value="weekly">Spend This Week ($)</option>
+            <option value="monthly">Spend This Month ($)</option>
+            <option value="total">Spend All-Time ($)</option>
+        </select>
+    </sdpi-item>
+
+    <sdpi-item id="topRow" label="Top Bar">
         <select id="topMetric" class="sdpi-item-value">
             <option value="limit">Key Limit (%)</option>
             <option value="daily">Spend Today ($)</option>
@@ -62,7 +82,7 @@
         </select>
     </sdpi-item>
 
-    <sdpi-item label="Bottom Bar">
+    <sdpi-item id="bottomRow" label="Bottom Bar">
         <select id="bottomMetric" class="sdpi-item-value">
             <option value="limit">Key Limit (%)</option>
             <option value="daily">Spend Today ($)</option>
@@ -110,16 +130,29 @@
 
         function applySettings() {
             document.getElementById("apiKey").value = _settings.apiKey || "";
+            document.getElementById("layout").value = _settings.layout || "bars";
+            document.getElementById("metric").value = _settings.metric || "limit";
             document.getElementById("topMetric").value = _settings.topMetric || "limit";
             document.getElementById("bottomMetric").value = _settings.bottomMetric || "monthly";
             document.getElementById("showProviderName").checked = _settings.showProviderName !== false;
+            applyLayoutVisibility();
+        }
+
+        function applyLayoutVisibility() {
+            const isRing = document.getElementById("layout").value === "ring";
+            document.getElementById("ringRow").classList.toggle("hidden", !isRing);
+            document.getElementById("topRow").classList.toggle("hidden", isRing);
+            document.getElementById("bottomRow").classList.toggle("hidden", isRing);
         }
 
         function saveSettings() {
             _settings.apiKey = document.getElementById("apiKey").value || "";
+            _settings.layout = document.getElementById("layout").value || "bars";
+            _settings.metric = document.getElementById("metric").value || "limit";
             _settings.topMetric = document.getElementById("topMetric").value || "limit";
             _settings.bottomMetric = document.getElementById("bottomMetric").value || "monthly";
             _settings.showProviderName = document.getElementById("showProviderName").checked;
+            applyLayoutVisibility();
 
             if (_websocket && _uuid) {
                 _websocket.send(JSON.stringify({
@@ -143,9 +176,9 @@
 
         document.addEventListener("DOMContentLoaded", function () {
             document.getElementById("apiKey").addEventListener("input", saveSettings);
-            document.getElementById("topMetric").addEventListener("change", saveSettings);
-            document.getElementById("bottomMetric").addEventListener("change", saveSettings);
-            document.getElementById("showProviderName").addEventListener("change", saveSettings);
+            ["layout", "metric", "topMetric", "bottomMetric", "showProviderName"].forEach(function (id) {
+                document.getElementById(id).addEventListener("change", saveSettings);
+            });
             applySettings();
         });
     </script>

--- a/src/actions/antigravity-progress-bars.ts
+++ b/src/actions/antigravity-progress-bars.ts
@@ -1,36 +1,26 @@
 import streamDeck, { action } from "@elgato/streamdeck";
 import { ProviderName, StandardUsageResult, AntigravityProvider } from "@lenadweb/ai-limits";
-import { AntigravitySettings } from "../interfaces/settings";
+import { AntigravitySettings, TileLayout } from "../interfaces/settings";
 import { BaseMonitoringAction } from "./base-monitoring-action";
 import { ServiceTheme } from "../interfaces/theme";
+import { Slot } from "../ui/progress-bar-renderer";
+import { formatTimeUntil } from "../utils/time-formatter";
 
 @action({ UUID: "com.len.limits.antigravity" })
 export class AntigravityProgressBars extends BaseMonitoringAction<AntigravitySettings> {
     protected readonly providerName = ProviderName.Antigravity;
     protected readonly themeName: ServiceTheme = "antigravity";
-    private topModel: string = "";
-    private bottomModel: string = "";
     private cachedLabels: Record<string, string> = {};
     private provider!: AntigravityProvider;
 
     override async onWillAppear(ev: any): Promise<void> {
         this.provider = this.limitsManager.getAntigravityProvider();
-        const settings = ev.payload?.settings as AntigravitySettings | undefined;
-        if (settings) {
-            this.topModel = settings.topModel || "";
-            this.bottomModel = settings.bottomModel || "";
-            this.cachedLabels = settings.availableModelLabels || {};
-        }
+        this.cachedLabels = { ...this.cachedLabels, ...(ev.payload?.settings?.availableModelLabels ?? {}) };
         await super.onWillAppear(ev);
     }
 
     override async onDidReceiveSettings(ev: any): Promise<void> {
-        const settings = ev.payload?.settings as AntigravitySettings | undefined;
-        if (settings) {
-            this.topModel = settings.topModel || "";
-            this.bottomModel = settings.bottomModel || "";
-            this.cachedLabels = settings.availableModelLabels || this.cachedLabels;
-        }
+        this.cachedLabels = { ...this.cachedLabels, ...(ev.payload?.settings?.availableModelLabels ?? {}) };
         await this.redraw(ev);
     }
 
@@ -129,8 +119,6 @@ export class AntigravityProgressBars extends BaseMonitoringAction<AntigravitySet
             ) {
                 await ev.action.setSettings({
                     ...currentSettings,
-                    topModel: this.topModel,
-                    bottomModel: this.bottomModel,
                     availableModels: models,
                     availableModelLabels: mergedLabels,
                     loggedInEmail: this.provider.getLoggedInEmail() || undefined
@@ -171,15 +159,26 @@ export class AntigravityProgressBars extends BaseMonitoringAction<AntigravitySet
     }
 
     protected getDisplayData(ev: any, result: StandardUsageResult) {
-        const top = this.getModelData(this.topModel, result);
-        const bottom = this.getModelData(this.bottomModel, result);
+        const settings = (ev?.payload?.settings ?? {}) as AntigravitySettings;
+        const layout: TileLayout = settings.layout ?? "bars";
+
+        if (layout === "ring") {
+            return this.tileDisplay([this.modelSlot(settings.model ?? "", result)], layout);
+        }
+
+        return this.tileDisplay([
+            this.modelSlot(settings.topModel ?? "", result),
+            this.modelSlot(settings.bottomModel ?? "", result)
+        ], layout);
+    }
+
+    private modelSlot(modelKey: string, result: StandardUsageResult): Slot {
+        const data = this.getModelData(modelKey, result);
         return {
-            value1: top.usage,
-            value2: bottom.usage,
-            label1: top.label,
-            label2: bottom.label,
-            resetTime1: top.resetTime,
-            resetTime2: bottom.resetTime
+            kind: "gauge",
+            label: data.label,
+            percent: data.usage,
+            caption: data.resetTime ? formatTimeUntil(data.resetTime) : undefined
         };
     }
 }

--- a/src/actions/base-monitoring-action.ts
+++ b/src/actions/base-monitoring-action.ts
@@ -2,10 +2,18 @@ import streamDeck, { SingletonAction, KeyDownEvent, WillAppearEvent, WillDisappe
 import { ProviderName, StandardUsageResult } from "@lenadweb/ai-limits";
 import { ProgressBarRenderer, Slot, RenderOptions } from "../ui/progress-bar-renderer";
 import { ServiceTheme } from "../interfaces/theme";
+import { TileLayout } from "../interfaces/settings";
 import { LimitsManager } from "../services/limits-manager";
 
+/** A single placed tile: its own controller kind and its own settings. */
+interface TileInstance<T> {
+    action: any;
+    controller: string;
+    settings: T;
+}
+
 export abstract class BaseMonitoringAction<T extends Record<string, any>> extends SingletonAction<T> {
-    protected controllers = new Map<string, string>();
+    protected instances = new Map<string, TileInstance<T>>();
     protected intervalId: NodeJS.Timeout | null = null;
     protected isMonitoring = false;
     protected lastResult: StandardUsageResult | null = null;
@@ -18,7 +26,7 @@ export abstract class BaseMonitoringAction<T extends Record<string, any>> extend
     protected abstract get themeName(): ServiceTheme;
 
     override async onWillAppear(ev: WillAppearEvent<T>): Promise<void> {
-        this.controllers.set(ev.action.id, ev.payload.controller);
+        this.track(ev, ev.payload.controller);
         // Draw cached data immediately so switching pages/folders never blanks the key
         await this.redraw(ev);
         if (!this.isMonitoring) {
@@ -28,8 +36,8 @@ export abstract class BaseMonitoringAction<T extends Record<string, any>> extend
     }
 
     override async onWillDisappear(ev: WillDisappearEvent<T>): Promise<void> {
-        this.controllers.delete(ev.action.id);
-        if (this.controllers.size === 0) {
+        this.instances.delete(ev.action.id);
+        if (this.instances.size === 0) {
             this.stopMonitoring();
             this.isMonitoring = false;
         }
@@ -55,6 +63,31 @@ export abstract class BaseMonitoringAction<T extends Record<string, any>> extend
         await this.refresh(ev);
     }
 
+    /**
+     * Remember the tile behind an event, along with its current settings. Every draw
+     * path funnels through here so the cache stays fresh even when a subclass
+     * overrides the event handlers without calling super.
+     */
+    protected track(ev: any, controller?: string): void {
+        const id = ev?.action?.id;
+        if (!id) return;
+
+        const existing = this.instances.get(id);
+        this.instances.set(id, {
+            action: ev.action,
+            controller: controller ?? existing?.controller ?? "Keypad",
+            settings: (ev.payload?.settings ?? existing?.settings ?? {}) as T
+        });
+    }
+
+    /** Event-shaped view of a tracked tile, so draw code can stay event-driven. */
+    protected asEvent(instance: TileInstance<T>): any {
+        return {
+            action: instance.action,
+            payload: { settings: instance.settings, controller: instance.controller }
+        };
+    }
+
     protected startMonitoring(ev: any): void {
         // Only hit the network on a cold start or when the cached data has gone stale,
         // so re-appearing after a page/folder switch doesn't trigger a visible refresh.
@@ -77,17 +110,31 @@ export abstract class BaseMonitoringAction<T extends Record<string, any>> extend
     }
 
     protected async refresh(ev: any): Promise<void> {
+        this.track(ev);
         try {
             const result = await this.fetchProviderUsage(ev);
             this.lastResult = result;
             this.lastFetchTime = Date.now();
-            await this.draw(ev, result);
+            // One fetch feeds every tile of this provider, each rendered with its own
+            // settings — several tiles can show different metrics of the same data.
+            await this.drawAll(result);
         } catch (err: any) {
             streamDeck.logger.error(`[${this.providerName}] Refresh failed: ${err}`);
         }
     }
 
+    protected async drawAll(result: StandardUsageResult): Promise<void> {
+        for (const instance of [...this.instances.values()]) {
+            try {
+                await this.draw(this.asEvent(instance), result);
+            } catch (err: any) {
+                streamDeck.logger.error(`[${this.providerName}] Draw failed: ${err}`);
+            }
+        }
+    }
+
     protected async redraw(ev: any): Promise<void> {
+        this.track(ev);
         if (this.lastResult) {
             await this.draw(ev, this.lastResult);
         } else {
@@ -100,16 +147,24 @@ export abstract class BaseMonitoringAction<T extends Record<string, any>> extend
     }
 
     protected abstract getDisplayData(ev: any, result: StandardUsageResult): {
-        value1: number;
-        value2: number;
-        label1: string;
-        label2: string;
+        value1?: number;
+        value2?: number;
+        label1?: string;
+        label2?: string;
         resetTime1?: string | null;
         resetTime2?: string | null;
         valueText1?: string;
         valueText2?: string;
         slots?: Slot[];
+        /** When set, the tile renders as a single ring gauge instead of bars. */
+        ring?: Slot;
     };
+
+    /** Package the slots a tile wants to show into the shape {@link draw} expects. */
+    protected tileDisplay(slots: (Slot | null)[], layout: TileLayout) {
+        const visible = slots.filter((slot): slot is Slot => slot !== null);
+        return layout === "ring" ? { ring: visible[0] } : { slots: visible };
+    }
 
     protected renderOptions(ev: any): RenderOptions {
         return { showName: ev?.payload?.settings?.showProviderName !== false };
@@ -129,21 +184,23 @@ export abstract class BaseMonitoringAction<T extends Record<string, any>> extend
 
         const data = this.getDisplayData(ev, result);
         const renderAt = (w: number, h: number) =>
-            data.slots
-                ? this.renderer.renderSlots(data.slots, this.themeName, w, h, opts)
-                : this.renderer.render(
-                    data.value1,
-                    data.value2,
-                    this.themeName,
-                    data.resetTime1,
-                    data.resetTime2,
-                    data.label1,
-                    data.label2,
-                    w, h,
-                    data.valueText1,
-                    data.valueText2,
-                    opts
-                );
+            data.ring
+                ? this.renderer.renderRing(data.ring, this.themeName, w, h, opts)
+                : data.slots
+                    ? this.renderer.renderSlots(data.slots, this.themeName, w, h, opts)
+                    : this.renderer.render(
+                        data.value1 ?? 0,
+                        data.value2 ?? 0,
+                        this.themeName,
+                        data.resetTime1,
+                        data.resetTime2,
+                        data.label1 ?? "",
+                        data.label2 ?? "",
+                        w, h,
+                        data.valueText1,
+                        data.valueText2,
+                        opts
+                    );
 
         const svg = renderAt(144, 144);
         const image = `data:image/svg+xml;base64,${Buffer.from(svg).toString("base64")}`;
@@ -174,7 +231,7 @@ export abstract class BaseMonitoringAction<T extends Record<string, any>> extend
     }
 
     protected async updateDialFeedback(ev: any, svg: string): Promise<void> {
-        const controller = this.controllers.get(ev.action.id);
+        const controller = this.instances.get(ev.action.id)?.controller ?? ev?.payload?.controller;
         if (controller === "Encoder") {
             const feedback = {
                 full_view: `data:image/svg+xml;base64,${Buffer.from(svg).toString("base64")}`

--- a/src/actions/codex-progress-bars.ts
+++ b/src/actions/codex-progress-bars.ts
@@ -1,10 +1,13 @@
 import { action } from "@elgato/streamdeck";
-import { ProviderName, StandardUsageResult } from "@lenadweb/ai-limits";
-import { CodexSecondaryMetric, CodexSettings } from "../interfaces/settings";
+import { ModelUsage, ProviderName, StandardUsageResult } from "@lenadweb/ai-limits";
+import { CodexMetric, CodexSettings, TileLayout } from "../interfaces/settings";
 import { BaseMonitoringAction } from "./base-monitoring-action";
 import { ServiceTheme } from "../interfaces/theme";
 import { Slot } from "../ui/progress-bar-renderer";
 import { formatTimeUntil } from "../utils/time-formatter";
+
+/** A window at least this long counts as a long-term (weekly) limit, not a session. */
+const LONG_WINDOW_SECONDS = 24 * 60 * 60;
 
 @action({ UUID: "com.len.limits.codex.progress" })
 export class CodexProgressBars extends BaseMonitoringAction<CodexSettings> {
@@ -12,60 +15,120 @@ export class CodexProgressBars extends BaseMonitoringAction<CodexSettings> {
     protected readonly themeName: ServiceTheme = "codex";
 
     protected getDisplayData(ev: any, result: StandardUsageResult) {
-        const primary = result.perModel?.["primary_window"];
-        const sessionSlot: Slot = {
-            kind: "gauge",
-            label: "Session",
-            percent: primary?.usagePercent ?? 0,
-            caption: primary?.resetTime ? formatTimeUntil(primary.resetTime) : undefined
-        };
-        const metric = (ev?.payload?.settings?.secondaryMetric ?? "resetCredits") as CodexSecondaryMetric;
-        const slots: Slot[] = [
-            sessionSlot,
-            ...(metric === "none" ? [] : [this.secondarySlot(metric, result)])
-        ];
+        const config = this.resolveSettings((ev?.payload?.settings ?? {}) as CodexSettings);
 
+        if (config.layout === "ring") {
+            return this.tileDisplay([this.metricSlot(config.metric, result)], config.layout);
+        }
+
+        return this.tileDisplay([
+            this.metricSlot(config.topMetric, result),
+            this.metricSlot(config.bottomMetric, result)
+        ], config.layout);
+    }
+
+    /**
+     * Tiles configured before the metric picker existed carry `secondaryMetric`;
+     * keep serving that as the bottom slot. The weekly window is the default metric
+     * because it is the one every plan still exposes.
+     */
+    private resolveSettings(settings: CodexSettings): {
+        layout: TileLayout;
+        metric: CodexMetric;
+        topMetric: CodexMetric;
+        bottomMetric: CodexMetric;
+    } {
+        const legacy = settings.secondaryMetric;
         return {
-            value1: slots[0].percent ?? 0,
-            value2: slots[1]?.percent ?? 0,
-            label1: slots[0].label,
-            label2: slots[1]?.label ?? "",
-            slots
+            layout: settings.layout ?? "bars",
+            metric: settings.metric ?? "weekly",
+            topMetric: settings.topMetric ?? "weekly",
+            bottomMetric: settings.bottomMetric ?? legacy ?? "resetCredits"
         };
     }
 
-    private secondarySlot(metric: CodexSecondaryMetric | undefined, result: StandardUsageResult): Slot {
-        if (metric === "resetCredits") {
-            const resets = result.rateLimitResetCredits;
-            if (!resets) {
-                return { kind: "stat", label: "Usage limit resets", valueText: "None" };
-            }
+    private metricSlot(metric: CodexMetric, result: StandardUsageResult): Slot | null {
+        if (metric === "none") return null;
+        if (metric === "session" || metric === "weekly") return this.windowSlot(metric, result);
+        if (metric === "resetCredits") return this.resetCreditsSlot(result);
+        return this.creditsSlot(result);
+    }
 
-            const { availableCount, applicableAvailableCount } = resets;
-            return {
-                kind: "stat",
-                label: "Usage limit resets",
-                valueText: availableCount === applicableAvailableCount
-                    ? String(availableCount)
-                    : `${applicableAvailableCount}/${availableCount}`,
-                caption: availableCount === applicableAvailableCount ? "available" : "applicable / total"
-            };
+    private windowSlot(metric: "session" | "weekly", result: StandardUsageResult): Slot {
+        const bucket = this.windows(result)[metric];
+        const label = metric === "session" ? "Session" : "Week";
+
+        if (!bucket) {
+            return { kind: "stat", label, valueText: "—", caption: "no data", muted: true };
         }
 
+        return {
+            kind: "gauge",
+            label: this.windowLabel(bucket, label),
+            percent: bucket.usagePercent ?? 0,
+            caption: bucket.resetTime ? formatTimeUntil(bucket.resetTime) : undefined
+        };
+    }
+
+    /**
+     * OpenAI dropped the 5-hour window on several plans, and when it does the weekly
+     * window arrives as `primary_window` — so classify the buckets by the duration the
+     * API reports rather than trusting their slot order (issue #6).
+     */
+    private windows(result: StandardUsageResult): { session: ModelUsage | undefined; weekly: ModelUsage | undefined } {
+        const primary = result.perModel?.["primary_window"];
+        const secondary = result.perModel?.["secondary_window"];
+
+        if (primary?.windowSeconds != null && primary.windowSeconds >= LONG_WINDOW_SECONDS) {
+            return { session: undefined, weekly: primary };
+        }
+        return { session: primary, weekly: secondary };
+    }
+
+    /** Name a long window after the period the API actually reports, when it reports one. */
+    private windowLabel(bucket: ModelUsage, fallback: string): string {
+        const seconds = bucket.windowSeconds;
+        if (seconds == null || seconds < LONG_WINDOW_SECONDS) return fallback;
+        if (seconds >= 28 * LONG_WINDOW_SECONDS) return "Month";
+        if (seconds >= 7 * LONG_WINDOW_SECONDS) return "Week";
+        return `${Math.round(seconds / LONG_WINDOW_SECONDS)}d`;
+    }
+
+    private resetCreditsSlot(result: StandardUsageResult): Slot {
+        const resets = result.rateLimitResetCredits;
+        if (!resets) {
+            return { kind: "stat", label: "Usage limit resets", shortLabel: "Resets", valueText: "None" };
+        }
+
+        const { availableCount, applicableAvailableCount } = resets;
+        return {
+            kind: "stat",
+            label: "Usage limit resets",
+            shortLabel: "Resets",
+            valueText: availableCount === applicableAvailableCount
+                ? String(availableCount)
+                : `${applicableAvailableCount}/${availableCount}`,
+            caption: availableCount === applicableAvailableCount ? "available" : "applicable / total"
+        };
+    }
+
+    private creditsSlot(result: StandardUsageResult): Slot {
         const credits = result.credits;
+        const label = { label: "Credits balance", shortLabel: "Credits" } as const;
+
         if (!credits) {
-            return { kind: "stat", label: "Credits balance", valueText: "—" };
+            return { kind: "stat", ...label, valueText: "—" };
         }
         if (credits.unlimited) {
-            return { kind: "stat", label: "Credits balance", valueText: "∞", caption: "unlimited" };
+            return { kind: "stat", ...label, valueText: "∞", caption: "unlimited" };
         }
         if (!credits.hasCredits) {
-            return { kind: "stat", label: "Credits balance", valueText: "0$" };
+            return { kind: "stat", ...label, valueText: "0$" };
         }
 
         return {
             kind: "stat",
-            label: "Credits balance",
+            ...label,
             valueText: credits.balance ?? "Available",
             caption: credits.balance == null ? undefined : "available"
         };

--- a/src/actions/gemini-cli-progress-bars.ts
+++ b/src/actions/gemini-cli-progress-bars.ts
@@ -1,33 +1,15 @@
-import streamDeck, { action } from "@elgato/streamdeck";
+import { action } from "@elgato/streamdeck";
 import { ProviderName, StandardUsageResult } from "@lenadweb/ai-limits";
-import { GeminiSettings } from "../interfaces/settings";
+import { GeminiSettings, TileLayout } from "../interfaces/settings";
 import { BaseMonitoringAction } from "./base-monitoring-action";
 import { ServiceTheme } from "../interfaces/theme";
+import { Slot } from "../ui/progress-bar-renderer";
+import { formatTimeUntil } from "../utils/time-formatter";
 
 @action({ UUID: "com.len.limits.gemini-cli" })
 export class GeminiCliProgressBars extends BaseMonitoringAction<GeminiSettings> {
     protected readonly providerName = ProviderName.Gemini;
     protected readonly themeName: ServiceTheme = "gemini-cli";
-    private topModel: string = "";
-    private bottomModel: string = "";
-
-    override async onWillAppear(ev: any): Promise<void> {
-        const settings = ev.payload?.settings as GeminiSettings | undefined;
-        if (settings) {
-            this.topModel = settings.topModel || "";
-            this.bottomModel = settings.bottomModel || "";
-        }
-        await super.onWillAppear(ev);
-    }
-
-    override async onDidReceiveSettings(ev: any): Promise<void> {
-        const settings = ev.payload?.settings as GeminiSettings | undefined;
-        if (settings) {
-            this.topModel = settings.topModel || "";
-            this.bottomModel = settings.bottomModel || "";
-        }
-        await this.redraw(ev);
-    }
 
     override async refresh(ev: any): Promise<void> {
         await super.refresh(ev);
@@ -56,17 +38,13 @@ export class GeminiCliProgressBars extends BaseMonitoringAction<GeminiSettings> 
         return Object.keys(this.lastResult.perModel);
     }
 
+    /** Cache the model list in the tile's settings so the picker works offline. */
     private async persistModelsToSettings(ev: any): Promise<void> {
         const models = this.getAvailableModels();
         try {
             const currentSettings = (ev.payload?.settings ?? {}) as GeminiSettings;
             if (JSON.stringify(currentSettings.availableModels) !== JSON.stringify(models)) {
-                await ev.action.setSettings({
-                    ...currentSettings,
-                    topModel: this.topModel,
-                    bottomModel: this.bottomModel,
-                    availableModels: models
-                });
+                await ev.action.setSettings({ ...currentSettings, availableModels: models });
             }
         } catch {}
     }
@@ -98,15 +76,26 @@ export class GeminiCliProgressBars extends BaseMonitoringAction<GeminiSettings> 
     }
 
     protected getDisplayData(ev: any, result: StandardUsageResult) {
-        const top = this.getModelData(this.topModel, result);
-        const bottom = this.getModelData(this.bottomModel, result);
+        const settings = (ev?.payload?.settings ?? {}) as GeminiSettings;
+        const layout: TileLayout = settings.layout ?? "bars";
+
+        if (layout === "ring") {
+            return this.tileDisplay([this.modelSlot(settings.model ?? "", result)], layout);
+        }
+
+        return this.tileDisplay([
+            this.modelSlot(settings.topModel ?? "", result),
+            this.modelSlot(settings.bottomModel ?? "", result)
+        ], layout);
+    }
+
+    private modelSlot(modelKey: string, result: StandardUsageResult): Slot {
+        const data = this.getModelData(modelKey, result);
         return {
-            value1: top.usage,
-            value2: bottom.usage,
-            label1: top.label,
-            label2: bottom.label,
-            resetTime1: top.resetTime,
-            resetTime2: bottom.resetTime
+            kind: "gauge",
+            label: data.label,
+            percent: data.usage,
+            caption: data.resetTime ? formatTimeUntil(data.resetTime) : undefined
         };
     }
 }

--- a/src/actions/minimax-progress-bars.ts
+++ b/src/actions/minimax-progress-bars.ts
@@ -1,9 +1,16 @@
 import { action } from "@elgato/streamdeck";
 import { LimitsClient, ProviderName, StandardUsageResult } from "@lenadweb/ai-limits";
-import { MiniMaxSettings } from "../interfaces/settings";
+import { MiniMaxMetric, MiniMaxSettings, TileLayout } from "../interfaces/settings";
 import { BaseMonitoringAction } from "./base-monitoring-action";
 import { ServiceTheme } from "../interfaces/theme";
+import { Slot } from "../ui/progress-bar-renderer";
+import { formatTimeUntil } from "../utils/time-formatter";
 import { streamDeckLogger } from "../services/limits-manager";
+
+const METRICS: Record<MiniMaxMetric, { label: string; key: string }> = {
+    daily: { label: "Daily", key: "general" },
+    weekly: { label: "Week", key: "weekly_interval" }
+};
 
 @action({ UUID: "com.len.limits.minimax" })
 export class MiniMaxProgressBars extends BaseMonitoringAction<MiniMaxSettings> {
@@ -17,8 +24,14 @@ export class MiniMaxProgressBars extends BaseMonitoringAction<MiniMaxSettings> {
     }
 
     override async onDidReceiveSettings(ev: any): Promise<void> {
+        const previousKey = this.settings.apiKey;
         this.settings = (ev.payload?.settings ?? {}) as MiniMaxSettings;
-        await this.refresh(ev);
+        // Only the API key needs a new request; metric changes redraw from cache.
+        if (this.settings.apiKey !== previousKey) {
+            await this.refresh(ev);
+        } else {
+            await this.redraw(ev);
+        }
     }
 
     protected override async fetchProviderUsage(ev: any): Promise<StandardUsageResult> {
@@ -36,15 +49,32 @@ export class MiniMaxProgressBars extends BaseMonitoringAction<MiniMaxSettings> {
     }
 
     protected getDisplayData(ev: any, result: StandardUsageResult) {
-        const general = result.perModel?.["general"];
-        const weekly = result.perModel?.["weekly_interval"];
+        const settings = (ev?.payload?.settings ?? {}) as MiniMaxSettings;
+        const layout: TileLayout = settings.layout ?? "bars";
+
+        if (layout === "ring") {
+            return this.tileDisplay([this.metricSlot(settings.metric ?? "daily", result)], layout);
+        }
+
+        return this.tileDisplay([
+            this.metricSlot(settings.topMetric ?? "daily", result),
+            this.metricSlot(settings.bottomMetric ?? "weekly", result)
+        ], layout);
+    }
+
+    private metricSlot(metric: MiniMaxMetric, result: StandardUsageResult): Slot {
+        const definition = METRICS[metric] ?? METRICS.daily;
+        const bucket = result.perModel?.[definition.key];
+
+        if (!bucket) {
+            return { kind: "stat", label: definition.label, valueText: "—", caption: "no data", muted: true };
+        }
+
         return {
-            value1: general?.usagePercent ?? 0,
-            value2: weekly?.usagePercent ?? 0,
-            label1: "Daily",
-            label2: "Week",
-            resetTime1: general?.resetTime,
-            resetTime2: weekly?.resetTime
+            kind: "gauge",
+            label: definition.label,
+            percent: bucket.usagePercent ?? 0,
+            caption: bucket.resetTime ? formatTimeUntil(bucket.resetTime) : undefined
         };
     }
 }

--- a/src/actions/openrouter-progress-bars.ts
+++ b/src/actions/openrouter-progress-bars.ts
@@ -1,6 +1,6 @@
 import { action } from "@elgato/streamdeck";
 import { LimitsClient, ProviderName, StandardUsageResult, OpenRouterProvider, OpenRouterUsage } from "@lenadweb/ai-limits";
-import { OpenRouterMetric, OpenRouterSettings } from "../interfaces/settings";
+import { OpenRouterMetric, OpenRouterSettings, TileLayout } from "../interfaces/settings";
 import { BaseMonitoringAction } from "./base-monitoring-action";
 import { ServiceTheme } from "../interfaces/theme";
 import { Slot } from "../ui/progress-bar-renderer";
@@ -20,14 +20,6 @@ export class OpenRouterProgressBars extends BaseMonitoringAction<OpenRouterSetti
     protected readonly themeName: ServiceTheme = "openrouter";
     private settings: OpenRouterSettings = {};
     private details: OpenRouterUsage | null = null;
-
-    private get topMetric(): OpenRouterMetric {
-        return this.settings.topMetric ?? "limit";
-    }
-
-    private get bottomMetric(): OpenRouterMetric {
-        return this.settings.bottomMetric ?? "monthly";
-    }
 
     override async onWillAppear(ev: any): Promise<void> {
         this.settings = (ev.payload?.settings ?? {}) as OpenRouterSettings;
@@ -74,14 +66,17 @@ export class OpenRouterProgressBars extends BaseMonitoringAction<OpenRouterSetti
     }
 
     protected getDisplayData(ev: any, result: StandardUsageResult) {
-        const slots = [this.metricSlot(this.topMetric), this.metricSlot(this.bottomMetric)];
-        return {
-            value1: slots[0].percent ?? 0,
-            value2: slots[1].percent ?? 0,
-            label1: slots[0].label,
-            label2: slots[1].label,
-            slots
-        };
+        const settings = (ev?.payload?.settings ?? {}) as OpenRouterSettings;
+        const layout: TileLayout = settings.layout ?? "bars";
+
+        if (layout === "ring") {
+            return this.tileDisplay([this.metricSlot(settings.metric ?? "limit")], layout);
+        }
+
+        return this.tileDisplay([
+            this.metricSlot(settings.topMetric ?? "limit"),
+            this.metricSlot(settings.bottomMetric ?? "monthly")
+        ], layout);
     }
 
     private metricSlot(metric: OpenRouterMetric): Slot {

--- a/src/actions/progress-bars.ts
+++ b/src/actions/progress-bars.ts
@@ -1,24 +1,50 @@
 import { action } from "@elgato/streamdeck";
 import { ProviderName, StandardUsageResult } from "@lenadweb/ai-limits";
-import { ProgressBarSettings } from "../interfaces/settings";
+import { ClaudeMetric, ClaudeSettings, TileLayout } from "../interfaces/settings";
 import { BaseMonitoringAction } from "./base-monitoring-action";
 import { ServiceTheme } from "../interfaces/theme";
+import { Slot } from "../ui/progress-bar-renderer";
+import { formatTimeUntil } from "../utils/time-formatter";
+
+/** Bucket keys vary per Claude plan/API version, so each metric accepts several. */
+const METRICS: Record<ClaudeMetric, { label: string; keys: string[] }> = {
+    session: { label: "Session", keys: ["five_hour", "5h_quota"] },
+    weekly: { label: "Week", keys: ["seven_day", "7d_quota"] },
+    weeklySonnet: { label: "Sonnet", keys: ["seven_day_sonnet", "7d_sonnet_quota"] }
+};
 
 @action({ UUID: "com.len.limits.progress" })
-export class ProgressBars extends BaseMonitoringAction<ProgressBarSettings> {
+export class ProgressBars extends BaseMonitoringAction<ClaudeSettings> {
     protected readonly providerName = ProviderName.Claude;
     protected readonly themeName: ServiceTheme = "claude";
 
     protected getDisplayData(ev: any, result: StandardUsageResult) {
-        const fiveHour = result.perModel?.["five_hour"] || result.perModel?.["5h_quota"];
-        const sevenDay = result.perModel?.["seven_day"] || result.perModel?.["seven_day_sonnet"] || result.perModel?.["7d_quota"] || result.perModel?.["7d_sonnet_quota"];
+        const settings = (ev?.payload?.settings ?? {}) as ClaudeSettings;
+        const layout: TileLayout = settings.layout ?? "bars";
+
+        if (layout === "ring") {
+            return this.tileDisplay([this.metricSlot(settings.metric ?? "session", result)], layout);
+        }
+
+        return this.tileDisplay([
+            this.metricSlot(settings.topMetric ?? "session", result),
+            this.metricSlot(settings.bottomMetric ?? "weekly", result)
+        ], layout);
+    }
+
+    private metricSlot(metric: ClaudeMetric, result: StandardUsageResult): Slot {
+        const definition = METRICS[metric] ?? METRICS.session;
+        const bucket = definition.keys.map((key) => result.perModel?.[key]).find(Boolean);
+
+        if (!bucket) {
+            return { kind: "stat", label: definition.label, valueText: "—", caption: "no data", muted: true };
+        }
+
         return {
-            value1: fiveHour?.usagePercent ?? 0,
-            value2: sevenDay?.usagePercent ?? 0,
-            label1: "Session",
-            label2: "Week",
-            resetTime1: fiveHour?.resetTime,
-            resetTime2: sevenDay?.resetTime
+            kind: "gauge",
+            label: definition.label,
+            percent: bucket.usagePercent ?? 0,
+            caption: bucket.resetTime ? formatTimeUntil(bucket.resetTime) : undefined
         };
     }
 }

--- a/src/interfaces/settings.ts
+++ b/src/interfaces/settings.ts
@@ -1,12 +1,36 @@
 export type ProgressBarSettings = Record<string, any>;
 
+/** How a single tile lays out its data: one ring gauge, or the two-slot bar view. */
+export type TileLayout = "ring" | "bars";
+
+export type ClaudeMetric = "session" | "weekly" | "weeklySonnet";
+
+export interface ClaudeSettings extends ProgressBarSettings {
+    layout?: TileLayout;
+    /** Metric shown by the ring layout. */
+    metric?: ClaudeMetric;
+    /** Metrics shown by the bars layout. */
+    topMetric?: ClaudeMetric;
+    bottomMetric?: ClaudeMetric;
+}
+
+export type CodexMetric = "session" | "weekly" | "resetCredits" | "credits" | "none";
+
+/** Pre-0.2 setting: the bottom slot of the (then only) bar layout. Migrated on read. */
 export type CodexSecondaryMetric = "credits" | "resetCredits" | "none";
 
 export interface CodexSettings extends ProgressBarSettings {
+    layout?: TileLayout;
+    metric?: CodexMetric;
+    topMetric?: CodexMetric;
+    bottomMetric?: CodexMetric;
     secondaryMetric?: CodexSecondaryMetric;
 }
 
 export interface GeminiSettings {
+    layout?: TileLayout;
+    /** Model shown by the ring layout; empty string means the overall quota. */
+    model?: string;
     topModel?: string;
     bottomModel?: string;
     availableModels?: string[];
@@ -14,6 +38,8 @@ export interface GeminiSettings {
 }
 
 export interface AntigravitySettings {
+    layout?: TileLayout;
+    model?: string;
     topModel?: string;
     bottomModel?: string;
     availableModels?: string[];
@@ -22,8 +48,14 @@ export interface AntigravitySettings {
     [key: string]: any;
 }
 
+export type MiniMaxMetric = "daily" | "weekly";
+
 export interface MiniMaxSettings {
     apiKey?: string;
+    layout?: TileLayout;
+    metric?: MiniMaxMetric;
+    topMetric?: MiniMaxMetric;
+    bottomMetric?: MiniMaxMetric;
     [key: string]: any;
 }
 
@@ -31,6 +63,8 @@ export type OpenRouterMetric = "limit" | "daily" | "weekly" | "monthly" | "total
 
 export interface OpenRouterSettings {
     apiKey?: string;
+    layout?: TileLayout;
+    metric?: OpenRouterMetric;
     topMetric?: OpenRouterMetric;
     bottomMetric?: OpenRouterMetric;
     [key: string]: any;

--- a/src/ui/progress-bar-renderer.ts
+++ b/src/ui/progress-bar-renderer.ts
@@ -3,9 +3,13 @@ import { ServiceTheme, ThemeColors } from "../interfaces/theme";
 export interface Slot {
     kind: "gauge" | "stat";
     label: string;
+    /** Used instead of {@link label} inside a ring, where horizontal space is tight. */
+    shortLabel?: string;
     percent?: number;
     valueText?: string;
     caption?: string;
+    /** Renders the value in the muted label colour, for placeholders like "no data". */
+    muted?: boolean;
 }
 
 export interface RenderOptions {
@@ -135,8 +139,97 @@ export class ProgressBarRenderer {
         return this.svg(width, height, chrome + modules);
     }
 
+    /**
+     * Single ring gauge filling the whole tile: label, value and reset time stacked
+     * inside the ring. Stat slots (credits, reset counts) keep the ring as a frame
+     * and simply show their value, so a mixed set of tiles still reads as one family.
+     */
+    renderRing(slot: Slot, theme: ServiceTheme = 'claude', width: number = 144, height: number = 144, opts: RenderOptions = {}): string {
+        const colors = this.themes[theme];
+        const isDial = this.isDial(width, height);
+        const showName = opts.showName !== false;
+        const geo = this.geometry(width, height, isDial, showName, 1);
+        const ring = this.ringGeometry(width, height, isDial, showName);
+
+        const isGauge = slot.kind !== "stat";
+        const pct = this.clampPct(slot.percent ?? 0);
+        const color = isGauge ? this.barColor(pct, theme) : colors.primary;
+        const value = slot.valueText ?? (isGauge ? `${pct}%` : "—");
+
+        const cx = this.round(ring.cx);
+        const cy = this.round(ring.cy);
+
+        let body = this.background(width, height, colors)
+            + this.header(this.serviceName(theme), colors, geo, isDial, showName);
+
+        body += `<circle cx="${cx}" cy="${cy}" r="${ring.r}" fill="none" stroke="${colors.barBg}" stroke-width="${ring.sw}" />`;
+        if (isGauge && pct > 0) {
+            const circumference = 2 * Math.PI * ring.r;
+            const filled = (circumference * pct) / 100;
+            body += `<circle cx="${cx}" cy="${cy}" r="${ring.r}" fill="none" stroke="${color}" stroke-width="${ring.sw}"`
+                + ` stroke-linecap="round" stroke-dasharray="${this.round(filled)} ${this.round(circumference)}"`
+                + ` transform="rotate(-90 ${cx} ${cy})" />`;
+        }
+
+        const labelText = slot.shortLabel ?? slot.label;
+        if (labelText) {
+            const max = this.chord(ring.inner, ring.labelDy, ring.labelSize);
+            // Model names can be long; shrink before falling back to an ellipsis.
+            const size = this.fitFontSize(labelText, ring.labelSize, ring.labelSize - 2.5, ProgressBarRenderer.SANS, max);
+            const label = this.fitText(labelText, size, ProgressBarRenderer.SANS, max, 600);
+            body += this.txt(ring.cx, ring.cy + ring.labelDy, label, size, 600, colors.label, "middle", ProgressBarRenderer.SANS);
+        }
+
+        const valueMax = this.chord(ring.inner, ring.valueDy, ring.valueSize);
+        const valueSize = this.fitFontSize(value, ring.valueSize, ring.valueMin, ProgressBarRenderer.SANS, valueMax);
+        const valueColor = slot.muted ? colors.label : color;
+        body += this.txt(ring.cx, ring.cy + ring.valueDy, this.escape(value), valueSize, 700, valueColor, "middle", ProgressBarRenderer.SANS);
+
+        // A clipped caption carries no information, so drop it rather than ellipsise it.
+        if (slot.caption) {
+            const max = this.chord(ring.inner, ring.captionDy, ring.captionSize);
+            if (this.measure(slot.caption, ring.captionSize, ProgressBarRenderer.SANS, 500) <= max) {
+                body += this.txt(ring.cx, ring.cy + ring.captionDy, this.escape(slot.caption), ring.captionSize, 500, colors.label, "middle", ProgressBarRenderer.SANS);
+            }
+        }
+
+        return this.svg(width, height, body);
+    }
+
     private isDial(w: number, h: number): boolean {
         return w === 200 && h === 100;
+    }
+
+    private ringGeometry(width: number, height: number, isDial: boolean, showName: boolean) {
+        const margin = isDial ? 12 : 15;
+        const left = isDial && showName ? 26 : margin;
+        const cx = (left + (width - margin)) / 2;
+
+        if (isDial) {
+            const r = 40, sw = 9;
+            return {
+                cx, cy: height / 2, r, sw, inner: r - sw / 2 - 2.5,
+                labelSize: 10, labelDy: -15,
+                valueSize: 24, valueMin: 13, valueDy: 8,
+                captionSize: 10, captionDy: 22
+            };
+        }
+
+        const r = showName ? 46 : 50;
+        const sw = showName ? 10 : 11;
+        return {
+            cx, cy: showName ? 84 : 72, r, sw, inner: r - sw / 2 - 3,
+            labelSize: 11, labelDy: -18,
+            valueSize: 30, valueMin: 15, valueDy: 9,
+            captionSize: 11, captionDy: 26
+        };
+    }
+
+    /** Widest line of text that still fits inside the ring at a given vertical offset. */
+    private chord(inner: number, dy: number, size: number): number {
+        const y = Math.max(Math.abs(dy), Math.abs(dy - size * 0.72));
+        if (y >= inner) return 0;
+        return 2 * Math.sqrt(inner * inner - y * y);
     }
 
     private geometry(width: number, height: number, isDial: boolean, showName: boolean, moduleCount = 2) {


### PR DESCRIPTION
## Why

A Stream Deck key is small, square, and read at a glance from across the room. The current layout splits that square into two half-height bars, so both numbers end up small and neither one stands out. In practice I am almost always watching a single number per key: how much of my weekly Codex budget is gone, or how close my Claude session is to running out.

The ring layout gives that one number the whole key. The percentage is large enough to read from a distance, the arc shows how full the window is without reading any digits at all, and the reset countdown sits in the middle instead of being squeezed inside a bar. The colour still shifts from the provider's own colour through amber to red as usage climbs.

A ring only makes sense if a tile can be told what to show, so every action also gets a metric picker, and the same action can now be placed more than once. Instead of one Claude key with two cramped bars, you can put a Claude session key next to a Claude weekly key, and give the ones you rarely look at a smaller spot on the deck. Building that surfaced two bugs worth fixing on their own: a second tile of the same provider never refreshed, and four providers stored their selection on the action rather than on the tile, so sibling tiles overwrote each other's choice.

The bars layout stays, and stays the default, for anyone who prefers the denser view. The Codex fix further down came out of the same work: checking what the tiles were actually rendering is what turned up #6.

## What this adds

Every action gains a **Layout** setting:

- **Bars** (default): the existing two-slot view, now with a metric picker for each slot.
- **Ring**: a single large ring gauge with the value and reset countdown inside it.

Each tile stores its own metric, so the same action can be placed several times to watch different windows side by side, for example one Claude tile on the 5-hour session and another on the 7-day window.

| Action | Metrics you can pick |
|---|---|
| Claude | session (5h), weekly (7d), Sonnet weekly (7d) |
| Codex | session, weekly, usage limit resets, credits balance |
| Antigravity, Gemini CLI | any reported model, or the overall quota |
| MiniMax | daily, weekly |
| OpenRouter | key limit, spend today / week / month / all-time |

## Fixes #6: Codex not showing weekly usage limits

Codex rate-limit windows were mapped by slot order: `primary_window` was always labelled "Session" and `secondary_window` always "Week". On plans where OpenAI dropped the 5-hour window, the API returns the **weekly** window as `primary_window` with `secondary_window: null`:

```json
"plan_type": "prolite",
"rate_limit": {
  "primary_window": { "used_percent": 72, "limit_window_seconds": 604800, ... },
  "secondary_window": null
}
```

So the weekly usage was shown under a "Session" label and the weekly bar stayed empty. Windows are now classified by the `limit_window_seconds` the API reports, where anything from 24h up counts as a long-term window. That keeps working whether or not OpenAI reinstates the 5-hour window. A window the API does not report renders as `no data` rather than a misleading 0%.

## Also fixed

`BaseMonitoringAction` held the `WillAppearEvent` of the first tile that appeared and refreshed only that one, so a second tile of the same provider never updated on the polling interval. It now tracks every placed tile with its own settings and draws all of them from a single fetch, so extra tiles cost no extra API calls.

Related: Antigravity, Gemini CLI, MiniMax and OpenRouter kept their model or metric selection in fields on the singleton action, so sibling tiles shared one selection, and Antigravity's `persistModelsToSettings` wrote one tile's choice over another's. All four now read their selection per tile.

## Compatibility

Existing tiles keep their appearance: `layout` defaults to `bars`, and Codex tiles saved with the older `secondaryMetric` setting keep serving it as their bottom slot.

## One thing to decide: where the Codex window logic belongs

CONTRIBUTING asks to keep domain logic in `@lenadweb/ai-limits`, and by that rule the window classification I added to `codex-progress-bars.ts` is in the wrong place. Deciding that a 604800 second window is a weekly limit is provider knowledge, not rendering.

I kept it in the plugin so this change stays inside one repo and does not depend on an unreleased library version. If you would rather have it in the ChatGPT provider in `ai-limits`, I am happy to open a PR there and rebase this one on top of the release. Everything else here is presentation and settings, which does belong in the actions.

## Testing

Verified against live Claude and Codex accounts (Claude `5h_quota` / `7d_quota`, Codex weekly window on a plan without a 5-hour window), on a 5x3 Stream Deck with Stream Deck 7.5.1. Key (144x144) and dial (200x100) renders checked for every provider theme, including 0%, 100%, missing-window and unlimited-credits states. `tsc --noEmit` and `npm run build` are clean.

Happy to adjust naming, defaults or scope if you would rather take this in smaller pieces, for instance the Codex window fix on its own first.
