### PR TITLE
Persist Gemini CLI and Antigravity model lists to every tile

### DIFF
--- a/src/actions/antigravity-progress-bars.ts
+++ b/src/actions/antigravity-progress-bars.ts
@@ -27,7 +27,7 @@ export class AntigravityProgressBars extends BaseMonitoringAction<AntigravitySet
     override async refresh(ev: any): Promise<void> {
         await super.refresh(ev);
         if (this.lastResult && !this.lastResult.error) {
-            await this.persistModelsToSettings(ev);
+            await this.persistModelsToSettings();
         }
     }
 
@@ -105,26 +105,36 @@ export class AntigravityProgressBars extends BaseMonitoringAction<AntigravitySet
         return labels;
     }
 
-    private async persistModelsToSettings(ev: any): Promise<void> {
+    /**
+     * Cache the model list in every tile's settings so each picker works offline.
+     * Writing to the refreshing tile alone would leave the other tiles of this
+     * action without a list.
+     */
+    private async persistModelsToSettings(): Promise<void> {
         const models = this.getAvailableModels();
         const labels = this.getModelLabels();
         const mergedLabels = { ...this.cachedLabels, ...labels };
         this.cachedLabels = mergedLabels;
+        const email = this.provider.getLoggedInEmail() || undefined;
 
-        try {
-            const currentSettings = (ev.payload?.settings ?? {}) as AntigravitySettings;
+        for (const instance of [...this.instances.values()]) {
+            const settings = (instance.settings ?? {}) as AntigravitySettings;
             if (
-                JSON.stringify(currentSettings.availableModels) !== JSON.stringify(models) ||
-                JSON.stringify(currentSettings.availableModelLabels) !== JSON.stringify(mergedLabels)
+                JSON.stringify(settings.availableModels) === JSON.stringify(models) &&
+                JSON.stringify(settings.availableModelLabels) === JSON.stringify(mergedLabels) &&
+                settings.loggedInEmail === email
             ) {
-                await ev.action.setSettings({
-                    ...currentSettings,
+                continue;
+            }
+            try {
+                await instance.action.setSettings({
+                    ...settings,
                     availableModels: models,
                     availableModelLabels: mergedLabels,
-                    loggedInEmail: this.provider.getLoggedInEmail() || undefined
+                    loggedInEmail: email
                 });
-            }
-        } catch {}
+            } catch {}
+        }
     }
 
     private getModelData(modelKey: string, result: StandardUsageResult): { usage: number; resetTime: string | null; label: string } {

--- a/src/actions/gemini-cli-progress-bars.ts
+++ b/src/actions/gemini-cli-progress-bars.ts
@@ -13,7 +13,7 @@ export class GeminiCliProgressBars extends BaseMonitoringAction<GeminiSettings> 
 
     override async refresh(ev: any): Promise<void> {
         await super.refresh(ev);
-        await this.persistModelsToSettings(ev);
+        await this.persistModelsToSettings();
     }
 
     override async onSendToPlugin(ev: any): Promise<void> {
@@ -38,15 +38,20 @@ export class GeminiCliProgressBars extends BaseMonitoringAction<GeminiSettings> 
         return Object.keys(this.lastResult.perModel);
     }
 
-    /** Cache the model list in the tile's settings so the picker works offline. */
-    private async persistModelsToSettings(ev: any): Promise<void> {
+    /**
+     * Cache the model list in every tile's settings so each picker works offline.
+     * Writing to the refreshing tile alone would leave the other tiles of this
+     * action without a list.
+     */
+    private async persistModelsToSettings(): Promise<void> {
         const models = this.getAvailableModels();
-        try {
-            const currentSettings = (ev.payload?.settings ?? {}) as GeminiSettings;
-            if (JSON.stringify(currentSettings.availableModels) !== JSON.stringify(models)) {
-                await ev.action.setSettings({ ...currentSettings, availableModels: models });
-            }
-        } catch {}
+        for (const instance of [...this.instances.values()]) {
+            const settings = (instance.settings ?? {}) as GeminiSettings;
+            if (JSON.stringify(settings.availableModels) === JSON.stringify(models)) continue;
+            try {
+                await instance.action.setSettings({ ...settings, availableModels: models });
+            } catch {}
+        }
     }
 
     private getModelData(modelKey: string, result: StandardUsageResult): { usage: number; resetTime: string | null; label: string } {


### PR DESCRIPTION
## Why

Gemini CLI and Antigravity cache their model list in the tile's settings, so the metric picker is already populated when the Property Inspector opens. That cache is written with `ev.action.setSettings()`, which reaches only the tile that happened to trigger the refresh. Every other tile of the same action keeps whatever it had, usually nothing.

This was harmless while an action was placed once. Since #8 encouraged placing the same action several times, one tile per model, it is now the normal case: the first Gemini tile has a cached list and the second one does not. The picker still works most of the time because it also asks the plugin over `getModels` when it opens, so the gap only shows when the plugin has no usage data yet or the fetch failed. Then one tile offers its models and the other offers an empty dropdown.

Claude has the same shape of cache, which is where I ran into this.

## What changed

Both `persistModelsToSettings()` methods now walk `this.instances` and write the cache to every tile of the action, instead of taking the refreshing tile from the event. Neither provider scopes its fetch per credential, so all their tiles share one result and one list.

Each tile is still compared before writing, so nothing is stored when the list has not changed.

## One extra fix in Antigravity

Antigravity persists `loggedInEmail` alongside the model list, but only inside the `if` that checks whether the models or labels changed. Logging in as someone else changes the email while the model list stays identical, so the new email was never written. The comparison now includes the email.
